### PR TITLE
Modify `io.js` to remove the use of `new` and `this`.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+    "globalstrict"  : true,
+    "devel"         : true,
+    "node"          : true,
+    "eqeqeq"        : true
+}

--- a/lib/infinispan.js
+++ b/lib/infinispan.js
@@ -27,7 +27,7 @@
 
     var TINY = 16, SMALL = 32, MEDIUM = 64, BIG = 128;
 
-    var transport = new io.transport(addrs, p);
+    var transport = io(addrs, p);
 
     // Context contains a byte buffer (buffer + offset) and generated message id
     function context(size) {

--- a/lib/io.js
+++ b/lib/io.js
@@ -10,9 +10,7 @@
   var f = require('./functional');
   var u = require('./utils');
 
-  exports.transport = function(addrs, protocol) {
-    return new Transport(addrs, protocol);
-  };
+  module.exports = transport;
 
   function showAddress(addr) { return addr.host + ':' + addr.port; }
   function showArrayAddress(addrs) {
@@ -33,14 +31,14 @@
       return function() {
         logger.debugf('Connected to %s', show());
         fulfill(conn);
-      }
+      };
     }
 
     function onError(reject) {
       return function(err) {
         logger.error('Error from %s: %s', show(), err.message);
         reject(err);
-      }
+      };
     }
 
     function onEnd() {
@@ -65,7 +63,7 @@
       topology.then(function() {
         logger.tracel(function() { return [
             'Complete %s for request(msgId=%d) with %s',
-            isError ? 'failure' : 'success', header.msgId, u.str(body.result)] });
+          isError ? 'failure' : 'success', header.msgId, u.str(body.result)]; });
 
         if (isError)
           rpc.fail(body.result);
@@ -113,12 +111,11 @@
       }
     }
 
-    return {
+    var o = {
       connect: function() {
-        var conn = this;
         return new Promise(function (fulfill, reject) {
           logger.debugf('Connecting to %s', show());
-          sock.connect(addr.port, addr.host, onConnect(fulfill, conn));
+          sock.connect(addr.port, addr.host, onConnect(fulfill, o));
           sock.on('error', onError(reject));
           sock.on('end', onEnd);
           sock.on('data', onData);
@@ -140,6 +137,7 @@
         return show();
       }
     };
+    return o;
   };
 
   var RpcMap = function() {
@@ -155,7 +153,7 @@
       remove: function(id) {
         promiseMap.remove(id);
       }
-    }
+    };
   };
 
   var RoundRobinRouter = function(logger, topologyId, conns) {
@@ -226,10 +224,10 @@
           return conn.disconnect();
         }
       }
-    }
+    };
   };
 
-  var Transport = function(addrs, protocol) {
+  function transport(addrs, protocol) {
     var logger = u.logger('transport');
     var rpcMap = new RpcMap();
     var emitter = new events.EventEmitter();
@@ -256,15 +254,14 @@
       return connected;
     }
 
-    return {
+    var o = {
       connect: function() {
-        var outer = this;
         // Convert to lazy connections
         var lazyConns = _.map(addrs, function(addr) {
           return function() {
-            var conn = new Connection(addr, outer);
+            var conn = new Connection(addr, o);
             return conn.connect();
-          }
+          };
         });
 
         // Set up router event callback
@@ -276,7 +273,7 @@
             .catch(function(error) { return f(); } ) // if fails, try next
             .then(function(conn) {
               emitter.emit('router', new FixedRouter(logger, conn));
-            })
+            });
         }, Promise.reject(new Error()));
       },
       disconnect: function() {
@@ -295,13 +292,12 @@
       findRpc: function(id) { return rpcMap.find(id); },
       removeRpc: function(id) { return rpcMap.remove(id); },
       updateTopology: function(bytebuf) {
-        var outer = this;
         var topology = protocol.decodeTopology(bytebuf);
         if (topology.done && !_.isEqual(topology.id, router.getTopologyId())) {
           var newAddrs = topology.servers;
           logger.debugl(function() {return [
               'New topology(id=%s) discovered: %s',
-              topology.id, showArrayAddress(newAddrs)] });
+            topology.id, showArrayAddress(newAddrs)]; });
 
           // Disconnect connections for members not present in topology
           var disconnectMany = router.disconnect(topology);
@@ -313,7 +309,7 @@
           // Then, create new connections for all added members
           var newConnected = disconnectMany.then(function() {
             return Promise.all(_.map(added, function(addr) {
-              return new Connection(addr, outer).connect();
+              return new Connection(addr, o).connect();
             }));
           });
           // Then, join these with the connected members and install new router
@@ -331,6 +327,7 @@
         return {topologyId: router.getTopologyId(), members: router.getAddresses()};
       }
     };
-  }
+    return o;
+  };
 
 }.call(this));


### PR DESCRIPTION
Looking at `infinispan.js` I noticed that the `io` package was being
used in an unusual way. [Here]
(https://github.com/infinispan/js-client/blob/master/lib/infinispan.js#L30)
the code is calling `new io.transport()`. This `transport` function is
also calling `new` [here]
(https://github.com/infinispan/js-client/blob/master/lib/io.js#L13-L15).
This is unnecessary, and potentially confusing. This commit addresses that.

In addition, @galderz, you mentioned that you were interested in keeping
the code as functional as possible, so in making the change above, I
have also eliminated the use of `Transport` as a constructor in favor of
it simply being a function. Doing that does not necessitate the removal
of `this`, but in general, I find that making assumptions about `this`
can lead to errors and in functional programming, it really shouldn't be
needed. So I've made changes to `io.transport` to eliminate `this` as
well.

Lastly, I added a basic .jshintrc and did a little code linting by
adding semi-colons.