### PR TITLE
ISPN-6381 - Add more tests for js-client

### DIFF
--- a/spec/functional_spec.js
+++ b/spec/functional_spec.js
@@ -2,11 +2,18 @@ var _ = require('underscore');
 var f = require('../lib/functional');
 
 function div(n, d) { return n / d }
+function performSomeCalculation(a, b, c) {
+  return (a + b) / c;
+}
 
 describe('Partial function application', function() {
   it('works with 2 parameters', function() {
     var div10By2 = f.partial2(div, 10, 2);
     expect(div10By2()).toBe(5);
+  });
+  it('works with 3 parameters', function() {
+    var action = f.partial3(performSomeCalculation, 10, 2, 3);
+    expect(action()).toBe(4);
   });
 });
 
@@ -14,6 +21,10 @@ describe('Curried function application', function() {
   it('works with 2 parameters', function() {
     var div10By2 = f.curry2(div)(2)(10);
     expect(div10By2).toBe(5);
+  });
+  it('works with 3 parameters', function() {
+    var action = f.curry3(performSomeCalculation)(3)(2)(10);
+    expect(action).toBe(4);
   });
 });
 
@@ -55,5 +66,8 @@ describe('Array concatenation', function() {
     var a1 = [1,2,3];
     var a2 = [4,5,6];
     expect(f.cat(a1, a2)).toEqual([1,2,3,4,5,6]);
+  });
+  it('tests cat method if no parameter is passed', function() {
+    expect(f.cat()).toEqual([]);
   });
 });

--- a/spec/infinispan_expiry_spec.js
+++ b/spec/infinispan_expiry_spec.js
@@ -4,6 +4,9 @@ var t = require('./utils/testing'); // Testing dependency
 
 describe('Infinispan local client working with expiry operations', function() {
   var client = t.client(t.local);
+  var client1 = t.client(t.cluster1);
+  var client2 = t.client(t.cluster2);
+  var client3 = t.client(t.cluster3);
 
   beforeEach(function(done) { client
       .then(t.assert(t.clear()))
@@ -16,7 +19,7 @@ describe('Infinispan local client working with expiry operations', function() {
     .then(assertError(t.replace('_', '_', {lifespan: 1}), t.toContain('Positive duration provided without time unit')))
     .then(assertError(t.putAll([{key: '_', value: '_'}], {lifespan: '1z'}), t.toContain('Unknown duration unit')))
     .then(assertError(t.replaceV('_', '_', '_', {lifespan: 1}), t.toContain('Positive duration provided without time unit')))
-    .catch(failed(done))
+    .catch(t.failed(done))
     .finally(done);
   });
   it('removes keys when their lifespan has expired', function(done) { client
@@ -31,32 +34,116 @@ describe('Infinispan local client working with expiry operations', function() {
     .then(t.assert(t.replace('life-replace', 'v1', {lifespan: '100000000ns'})))
     .then(t.assert(t.get('life-replace'), t.toBe('v1')))
     .then(waitLifespanExpire('life-replace'))
-    .catch(failed(done))
+    .catch(t.failed(done))
     .finally(done);
+  });
+  xit('removes keys when their lifespan has expired in cluster', function(done) { client1
+      .then(t.assert(t.put('life', 'value', {lifespan: '100ms'})))
+      .then(t.assert(t.containsKey('life'), t.toBeTruthy))
+      .then(function(client) {
+          return client2
+              .then(t.assert(t.containsKey('life'), t.toBeTruthy))
+              .then(waitLifespanExpire('life'))
+              .then(t.assert(t.putIfAbsent('life-absent', 'value', {lifespan: '100000μs'})))
+              .then(t.assert(t.containsKey('life-absent'), t.toBeTruthy))
+              .then(function() {
+                return client;
+              })
+      })
+      .then(function(client){
+        return client3
+            .then(t.assert(t.get('life-absent'), t.toBe('value')))
+            .then(waitLifespanExpire('life-absent'))
+            .then(t.assert(t.putIfAbsent('life-replace', 'v0')))
+            .then(t.assert(t.get('life-replace'), t.toBe('v0')))
+            .then(t.assert(t.replace('life-replace', 'v1', {lifespan: '100000000ns'})))
+            .then(function() {
+              return client;
+            })
+      })
+      .then(t.assert(t.get('life-replace'), t.toBe('v1')))
+      .then(waitLifespanExpire('life-replace'))
+      .catch(t.failed(done))
+      .finally(done);
   });
   it('removes keys when their max idle time has expired', function(done) {
     var pairs = [{key: 'idle-multi1', value: 'v1'}, {key: 'idle-multi2', value: 'v2'}];
     client
+        .then(t.assert(t.put('idle-replace', 'v0')))
+        .then(t.assert(t.conditional(t.replaceV, t.getV, 'idle-replace', 'v0', 'v1', {maxIdle: '100ms'}), t.toBeTruthy))
+        .then(t.assert(t.get('idle-replace'), t.toBe('v1')))
+        .then(waitIdleTimeExpire('idle-replace'))
+        .then(t.assert(t.putAll(pairs, {maxIdle: '100000μs'}), t.toBeUndefined))
+        .then(t.assert(t.containsKey('idle-multi2'), t.toBeTruthy))
+        .then(waitIdleTimeExpire('idle-multi2'))
+        .catch(t.failed(done))
+        .finally(done);
+  });
+  it('removes keys when their max idle time has expired in cluster', function(done) {
+    var pairs = [{key: 'idle-multi1', value: 'v1'}, {key: 'idle-multi2', value: 'v2'}];
+    client1
       .then(t.assert(t.put('idle-replace', 'v0')))
       .then(t.assert(t.conditional(t.replaceV, t.getV, 'idle-replace', 'v0', 'v1', {maxIdle: '100ms'}), t.toBeTruthy))
       .then(t.assert(t.get('idle-replace'), t.toBe('v1')))
-      .then(waitIdleTimeExpire('idle-replace'))
-      .then(t.assert(t.putAll(pairs, {maxIdle: '100000μs'}), t.toBeUndefined))
-      .then(t.assert(t.containsKey('idle-multi2'), t.toBeTruthy))
-      .then(waitIdleTimeExpire('idle-multi2'))
-      .catch(failed(done))
+      .then(function(client) {
+        return client2
+            .then(t.assert(t.get('idle-replace'), t.toBe('v1')))
+            .then(waitIdleTimeExpire('idle-replace'))
+            .then(t.assert(t.containsKey('idle-replace'), t.toBeFalsy))
+            .then(t.assert(t.putAll(pairs, {maxIdle: '100000μs'}), t.toBeUndefined))
+            .then(function() {
+              return client;
+            });
+      })
+      .then(function(client) {
+        return client3
+            .then(t.assert(t.containsKey('idle-multi2'), t.toBeTruthy))
+            .then(waitIdleTimeExpire('idle-multi2'))
+            .then(t.assert(t.containsKey('idle-multi2'), t.toBeFalsy))
+            .then(function() {
+              return client;
+            });
+      })
+      .then(t.assert(t.containsKey('idle-multi2'), t.toBeFalsy))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can listen for expired events', function(done) { client
     .then(t.assert(t.on('expiry', t.expectEvent('listen-expiry', undefined, t.removeListener(done)))))
     .then(t.assert(t.putIfAbsent('listen-expiry', 'value', {lifespan: '100ms'})))
     .then(waitForExpiryEvent('listen-expiry'))
-    .catch(failed(done));
+    .catch(t.failed(done));
+  });
+  it('can listen for expired events in cluster', function(done) { client1
+      .then(t.assert(t.on('expiry', t.expectEvent('listen-expiry', undefined, t.removeListener(done)))))
+      .then(t.assert(t.putIfAbsent('listen-expiry', 'value', {lifespan: '100ms'})))
+      .then(function(client) {
+        return client2
+            .then(t.assert(t.containsKey('listen-expiry'), t.toBeTruthy))
+            .then(waitForExpiryEvent('listen-expiry'))
+            .then(function() {
+              return client;
+            });
+      })
+      .then(t.assert(t.containsKey('listen-expiry'), t.toBeFalsy))
+      .catch(t.failed(done));
   });
   // Since Jasmine 1.3 does not have afterAll callback, this disconnect test must be last
   it('disconnects client', function(done) {
     client.then(t.disconnect())
-        .catch(failed(done))
+        .catch(t.failed(done))
+        .finally(done);
+
+    client1.then(t.disconnect())
+        .catch(t.failed(done))
+        .finally(done);
+
+    client2.then(t.disconnect())
+        .catch(t.failed(done))
+        .finally(done);
+
+    client3.then(t.disconnect())
+        .catch(t.failed(done))
         .finally(done);
   });
 
@@ -124,13 +211,5 @@ function assertError(fun, expectErrorFun) {
     return client;
   }
 }
-
-
-// TODO: Duplicate
-var failed = function(done) {
-  return function(error) {
-    done(error);
-  };
-};
 
 

--- a/spec/infinispan_local_spec.js
+++ b/spec/infinispan_local_spec.js
@@ -13,22 +13,18 @@ describe('Infinispan local client', function() {
       .catch(t.failed(done)).finally(done);
   });
 
-  var prev = function() {
-    return { previous: true };
-  };
-
   it('can put -> get -> remove a key/value pair', function(done) { client
     .then(t.assert(t.size(), t.toBe(0)))
     .then(t.assert(t.put('key', 'value')))
     .then(t.assert(t.size(), t.toBe(1)))
     .then(t.assert(t.get('key'), t.toBe('value')))
     .then(t.assert(t.containsKey('key'), t.toBeTruthy))
-    .then(t.assert(remove('key'), t.toBeTruthy))
+    .then(t.assert(t.remove('key'), t.toBeTruthy))
     .then(t.assert(t.get('key'), t.toBeUndefined))
     .then(t.assert(t.containsKey('key'), t.toBeFalsy))
-    .then(t.assert(remove('key'), t.toBeFalsy))
+    .then(t.assert(t.remove('key'), t.toBeFalsy))
     .then(t.assert(t.size(), t.toBe(0)))
-    .catch(failed(done))
+    .catch(t.failed(done))
     .finally(done);
   });
   it('can use conditional operations on a key/value pair', function(done) { client
@@ -40,33 +36,33 @@ describe('Infinispan local client', function() {
     .then(t.assert(t.get('cond'), t.toBe('v1')))
     .then(t.assert(t.conditional(t.replaceV, t.getV, 'cond', 'v1', 'v2'), t.toBeTruthy))
     .then(t.assert(t.get('cond'), t.toBe('v2')))
-    .then(t.assert(notReplaceWithVersion('_'), t.toBeFalsy)) // key not found
-    .then(t.assert(notReplaceWithVersion('cond'), t.toBeFalsy)) // key found but invalid version
+    .then(t.assert(t.notReplaceWithVersion('_'), t.toBeFalsy)) // key not found
+    .then(t.assert(t.notReplaceWithVersion('cond'), t.toBeFalsy)) // key found but invalid version
     .then(t.assert(t.get('cond'), t.toBe('v2')))
-    .then(t.assert(notRemoveWithVersion('_'), t.toBeFalsy))
-    .then(t.assert(notRemoveWithVersion('cond'), t.toBeFalsy))
+    .then(t.assert(t.notRemoveWithVersion('_'), t.toBeFalsy))
+    .then(t.assert(t.notRemoveWithVersion('cond'), t.toBeFalsy))
     .then(t.assert(t.get('cond'), t.toBe('v2')))
-    .then(t.assert(t.conditional(removeWithVersion, t.getV, 'cond', 'v2'), t.toBeTruthy))
+    .then(t.assert(t.conditional(t.removeWithVersion, t.getV, 'cond', 'v2'), t.toBeTruthy))
     .then(t.assert(t.get('cond'), t.toBeUndefined))
-    .catch(failed(done))
+    .catch(t.failed(done))
     .finally(done);
   });
   it('can return previous values', function(done) { client
-    .then(t.assert(t.putIfAbsent('prev', 'v0', prev()), t.toBeUndefined))
-    .then(t.assert(t.putIfAbsent('prev', 'v1', prev()), t.toBe('v0')))
-    .then(t.assert(remove('prev', prev()), t.toBe('v0')))
-    .then(t.assert(remove('prev', prev()), t.toBeUndefined))
-    .then(t.assert(t.put('prev', 'v1', prev()), t.toBeUndefined))
-    .then(t.assert(t.put('prev', 'v2', prev()), t.toBe('v1')))
-    .then(t.assert(t.replace('prev', 'v3', prev()), t.toBe('v2')))
-    .then(t.assert(t.replace('_', 'v3', prev()), t.toBeUndefined))
-    .then(t.assert(t.conditional(t.replaceV, t.getV, 'prev', 'v3', 'v4', prev()), t.toBe('v3')))
-    .then(t.assert(notReplaceWithVersion('_', prev()), t.toBeUndefined)) // key not found
-    .then(t.assert(notReplaceWithVersion('prev', prev()), t.toBe('v4'))) // key found but invalid version
-    .then(t.assert(notRemoveWithVersion('_', prev()), t.toBeUndefined)) // key not found
-    .then(t.assert(notRemoveWithVersion('prev', prev()), t.toBe('v4'))) // key found but invalid version
-    .then(t.assert(t.conditional(removeWithVersion, t.getV, 'prev', 'v4', prev()), t.toBe('v4')))
-    .catch(failed(done))
+    .then(t.assert(t.putIfAbsent('prev', 'v0', t.prev()), t.toBeUndefined))
+    .then(t.assert(t.putIfAbsent('prev', 'v1', t.prev()), t.toBe('v0')))
+    .then(t.assert(t.remove('prev', t.prev()), t.toBe('v0')))
+    .then(t.assert(t.remove('prev', t.prev()), t.toBeUndefined))
+    .then(t.assert(t.put('prev', 'v1', t.prev()), t.toBeUndefined))
+    .then(t.assert(t.put('prev', 'v2', t.prev()), t.toBe('v1')))
+    .then(t.assert(t.replace('prev', 'v3', t.prev()), t.toBe('v2')))
+    .then(t.assert(t.replace('_', 'v3', t.prev()), t.toBeUndefined))
+    .then(t.assert(t.conditional(t.replaceV, t.getV, 'prev', 'v3', 'v4', t.prev()), t.toBe('v3')))
+    .then(t.assert(t.notReplaceWithVersion('_', t.prev()), t.toBeUndefined)) // key not found
+    .then(t.assert(t.notReplaceWithVersion('prev', t.prev()), t.toBe('v4'))) // key found but invalid version
+    .then(t.assert(t.notRemoveWithVersion('_', t.prev()), t.toBeUndefined)) // key not found
+    .then(t.assert(t.notRemoveWithVersion('prev', t.prev()), t.toBe('v4'))) // key found but invalid version
+    .then(t.assert(t.conditional(t.removeWithVersion, t.getV, 'prev', 'v4', t.prev()), t.toBe('v4')))
+    .catch(t.failed(done))
     .finally(done);
   });
   it('can use multi-key operations', function(done) {
@@ -75,43 +71,43 @@ describe('Infinispan local client', function() {
     client
       .then(t.assert(t.putAll(pairs), t.toBeUndefined))
       .then(t.assert(t.size(), t.toBe(3)))
-      .then(t.assert(getAll(keys), toEqualPairs([{key: 'multi1', value: 'v1'}, {key: 'multi2', value: 'v2'}])))
-      .then(t.assert(getAll(['_']), toEqual([])))
-      .then(t.assert(getBulk(), toEqualPairs(pairs)))
-      .then(t.assert(getBulk(3), toEqualPairs(pairs)))
-      .then(t.assert(getBulkKeys(), toEqualPairs(['multi1', 'multi2', 'multi3'])))
-      .then(t.assert(getBulkKeys(3), toEqualPairs(['multi1', 'multi2', 'multi3'])))
-      .catch(failed(done))
+      .then(t.assert(t.getAll(keys), t.toEqualPairs([{key: 'multi1', value: 'v1'}, {key: 'multi2', value: 'v2'}])))
+      .then(t.assert(t.getAll(['_']), t.toEqual([])))
+      .then(t.assert(t.getBulk(), t.toEqualPairs(pairs)))
+      .then(t.assert(t.getBulk(3), t.toEqualPairs(pairs)))
+      .then(t.assert(t.getBulkKeys(), t.toEqualPairs(['multi1', 'multi2', 'multi3'])))
+      .then(t.assert(t.getBulkKeys(3), t.toEqualPairs(['multi1', 'multi2', 'multi3'])))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can ping a server', function(done) { client
     .then(t.assert(t.ping(), t.toBeUndefined))
-    .catch(failed(done))
+    .catch(t.failed(done))
     .finally(done);
   });
   it('can put -> get a big value', function(done) {
     var value = t.randomStr(128);
     client
       .then(t.assert(t.put('key', value)))
-      .then(t.assert(t.get('key'), toEqual(value)))
-      .catch(failed(done))
+      .then(t.assert(t.get('key'), t.toEqual(value)))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can put -> get a really big value', function(done) {
     var value = t.randomStr(1024 * 1024);
     client
       .then(t.assert(t.put('key', value)))
-      .then(t.assert(t.get('key'), toEqual(value)))
-      .catch(failed(done))
+      .then(t.assert(t.get('key'), t.toEqual(value)))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can put -> get -> remove a key/value pair on a named cache', function(done) {
     t.client(t.local, 'namedCache')
       .then(t.assert(t.put('key', 'value')))
       .then(t.assert(t.get('key'), t.toBe('value')))
-      .then(t.assert(remove('key'), t.toBeTruthy))
+      .then(t.assert(t.remove('key'), t.toBeTruthy))
       .then(t.disconnect())
-      .catch(failed(done))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can get key/value pairs with their immortal metadata', function(done) {
@@ -121,7 +117,7 @@ describe('Infinispan local client', function() {
       .then(t.assert(t.getM('meta'), t.toContain(f.merge({ value: 'v0' }, immortal))))
       .then(t.assert(t.conditional(t.replaceV, t.getM, 'meta', 'v0', 'v1'), t.toBeTruthy))
       .then(t.assert(t.getM('meta'), t.toContain(f.merge({ value: 'v1' }, immortal))))
-      .catch(failed(done))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can get key/value pairs with their expirable metadata', function(done) { client
@@ -131,26 +127,26 @@ describe('Infinispan local client', function() {
       .then(t.assert(t.getM('cond-exp-meta'), t.toContain({ value: 'v0', maxIdle : 2700})))
       .then(t.assert(t.replace('cond-exp-meta', 'v1', {lifespan: '1d', maxIdle: '1h'})))
       .then(t.assert(t.getM('cond-exp-meta'), t.toContain({ value: 'v1', lifespan: 86400, maxIdle : 3600})))
-      .catch(failed(done))
+      .catch(t.failed(done))
       .finally(done);
   });
   it('can listen for only create events', function(done) { client
       .then(t.assert(t.on('create', t.expectEvent('listen-create', 'value', t.removeListener(done)))))
       .then(t.assert(t.putIfAbsent('listen-create', 'value'), t.toBeTruthy))
-      .catch(failed(done));
+      .catch(t.failed(done));
   });
   it('can listen for only modified events', function(done) { client
       .then(t.assert(t.on('modify', t.expectEvent('listen-modify', 'v1', t.removeListener(done)))))
       .then(t.assert(t.putIfAbsent('listen-modify', 'v0'), t.toBeTruthy))
       .then(t.assert(t.replace('listen-modify', 'v1'), t.toBeTruthy))
-      .catch(failed(done));
+      .catch(t.failed(done));
   });
   it('can listen for only removed events', function(done) { client
       .then(t.assert(t.on('remove', t.expectEvent('listen-remove', undefined, t.removeListener(done)))))
       .then(t.assert(t.putIfAbsent('listen-remove', 'v0'), t.toBeTruthy))
       .then(t.assert(t.replace('listen-remove', 'v1'), t.toBeTruthy))
-      .then(t.assert(remove('listen-remove'), t.toBeTruthy))
-      .catch(failed(done));
+      .then(t.assert(t.remove('listen-remove'), t.toBeTruthy))
+      .catch(t.failed(done));
   });
   it('can listen for create/modified/remove events in distinct listeners', function(done) { client
       .then(t.assert(t.on('create', t.expectEvent('listen-distinct', 'v0', t.removeListener()))))
@@ -158,8 +154,8 @@ describe('Infinispan local client', function() {
       .then(t.assert(t.on('modify', t.expectEvent('listen-distinct', 'v1', t.removeListener()))))
       .then(t.assert(t.replace('listen-distinct', 'v1'), t.toBeTruthy))
       .then(t.assert(t.on('remove', t.expectEvent('listen-distinct', undefined, t.removeListener(done)))))
-      .then(t.assert(remove('listen-distinct'), t.toBeTruthy))
-      .catch(failed(done));
+      .then(t.assert(t.remove('listen-distinct'), t.toBeTruthy))
+      .catch(t.failed(done));
   });
   it('can listen for create/modified/remove events in same listener', function(done) { client
       .then(t.assert(t.onMany(
@@ -169,8 +165,8 @@ describe('Infinispan local client', function() {
           ])))
       .then(t.assert(t.putIfAbsent('listen-same', 'v0'), t.toBeTruthy))
       .then(t.assert(t.replace('listen-same', 'v1'), t.toBeTruthy))
-      .then(t.assert(remove('listen-same'), t.toBeTruthy))
-      .catch(failed(done));
+      .then(t.assert(t.remove('listen-same'), t.toBeTruthy))
+      .catch(t.failed(done));
   });
   it('can listen for state events when adding listener to non-empty cache', function(done) { client
       .then(t.assert(t.putIfAbsent('listen-state-0', 'v0'), t.toBeTruthy))
@@ -179,51 +175,55 @@ describe('Infinispan local client', function() {
       .then(t.assert(t.on('create', t.expectEvents(
           ['listen-state-0', 'listen-state-1', 'listen-state-2'], t.removeListener(done)),
           {'includeState' : true})))
-      .catch(failed(done));
+      .catch(t.failed(done));
   });
-  it('can iterate over entries', function(done) {
-    var pairs = [
-      {key: 'it1', value: 'v1', done: false},
-      {key: 'it2', value: 'v2', done: false},
-      {key: 'it3', value: 'v3', done: false}];
-    client
-        .then(t.assert(t.putAll(pairs), t.toBeUndefined))
-        .then(parIterator(1, pairs)) // Iterate all data, 1 element at time, parallel
-        .then(seqIterator(3, pairs)) // Iterate all data, 3 elements at time, sequential
-        .catch(failed(done))
-        .finally(done);
-  });
-  it('can iterate over entries getting their expirable metadata', function(done) {
-    var pairs = [{key: 'it-exp-1', value: 'v1'}, {key: 'it-exp-2', value: 'v2'}];
-    var expected = _.map(pairs, function(pair) {
-      return f.merge(pair, {done: false, lifespan: 86400, maxIdle : 3600});
+
+  if (process.env.protocol == null || process.env.protocol == '2.5') {
+    it('can iterate over entries', function (done) {
+      var pairs = [
+        {key: 'it1', value: 'v1', done: false},
+        {key: 'it2', value: 'v2', done: false},
+        {key: 'it3', value: 'v3', done: false}];
+      client
+          .then(t.assert(t.putAll(pairs), t.toBeUndefined))
+          .then(t.parIterator(1, pairs)) // Iterate all data, 1 element at time, parallel
+          .then(t.seqIterator(3, pairs)) // Iterate all data, 3 elements at time, sequential
+          .catch(t.failed(done))
+          .finally(done);
     });
-    client
-        .then(t.assert(t.putAll(pairs, {lifespan: '1d', maxIdle: '1h'}), t.toBeUndefined))
-        .then(parIterator(1, expected, {metadata: true})) // Iterate all data, 1 element at time, parallel
-        .then(seqIterator(3, expected, {metadata: true})) // Iterate all data, 3 elements at time, sequential
-        .catch(failed(done))
-        .finally(done);
-  });
+    it('can iterate over entries getting their expirable metadata', function (done) {
+      var pairs = [{key: 'it-exp-1', value: 'v1'}, {key: 'it-exp-2', value: 'v2'}];
+      var expected = _.map(pairs, function (pair) {
+        return f.merge(pair, {done: false, lifespan: 86400, maxIdle: 3600});
+      });
+      client
+          .then(t.assert(t.putAll(pairs, {lifespan: '1d', maxIdle: '1h'}), t.toBeUndefined))
+          .then(t.parIterator(1, expected, {metadata: true})) // Iterate all data, 1 element at time, parallel
+          .then(t.seqIterator(3, expected, {metadata: true})) // Iterate all data, 3 elements at time, sequential
+          .catch(t.failed(done))
+          .finally(done);
+    });
+  }
+
   it('can failover to a secondary node if first node is not available', function(done) {
     t.client([{port: 1234, host: '127.0.0.1'}, t.local])
         .then(t.assert(t.ping(), t.toBeUndefined))
         .then(t.disconnect())
-        .catch(failed(done))
+        .catch(t.failed(done))
         .finally(done);
   });
   it('can query statistic values', function(done) { client
-      .then(t.assertStats(t.put('stats-key', 'stats-value'), toBeStatIncr('stores')))
-      .then(t.assertStats(t.get('stats-key'), toBeStatIncr('hits')))
-      .then(t.assertStats(t.get('stats-miss-key'), toBeStatIncr('misses')))
-      .then(t.assertStats(remove('stats-miss-key'), toBeStatIncr('removeMisses')))
-      .then(t.assertStats(remove('stats-key'), toBeStatIncr('removeHits')))
-      .catch(failed(done)).finally(done);
+      .then(t.assertStats(t.put('stats-key', 'stats-value'), t.toBeStatIncr('stores')))
+      .then(t.assertStats(t.get('stats-key'), t.toBeStatIncr('hits')))
+      .then(t.assertStats(t.get('stats-miss-key'), t.toBeStatIncr('misses')))
+      .then(t.assertStats(t.remove('stats-miss-key'), t.toBeStatIncr('removeMisses')))
+      .then(t.assertStats(t.remove('stats-key'), t.toBeStatIncr('removeHits')))
+      .catch(t.failed(done)).finally(done);
   });
   it('can retrieve topology information', function(done) { client
     .then(t.assert(t.getTopologyId(), t.toBe(0)))
     .then(t.assert(t.getMembers(), t.toEqual([{host: '127.0.0.1', port: 11222}])))
-    .catch(failed(done)).finally(done);
+    .catch(t.failed(done)).finally(done);
   });
   it('can execute a script remotely to store and retrieve data', function(done) {
     Promise.all([client, readFile('spec/utils/typed-put-get.js')])
@@ -234,141 +234,13 @@ describe('Infinispan local client', function() {
         })
         .then(t.assert(t.exec('typed-put-get.js', {k: 'typed-key', v: 'typed-value'}),
                        t.toBe('typed-value')))
-        .catch(failed(done)).finally(done);
+        .catch(t.failed(done)).finally(done);
   });
   // Since Jasmine 1.3 does not have afterAll callback, this disconnect test must be last
   it('disconnects client', function(done) { client
       .then(t.disconnect())
-      .catch(failed(done))
+      .catch(t.failed(done))
       .finally(done);
   });
 
 });
-
-function getAll(keys) {
-  return function(client) {
-    return client.getAll(keys);
-  }
-}
-
-function remove(k, opts) {
-  return function(client) {
-    return client.remove(k, opts);
-  }
-}
-
-function getBulk(count) {
-  return function(client) {
-    return client.getBulk(count);
-  }
-}
-
-function getBulkKeys(count) {
-  return function(client) {
-    return client.getBulkKeys(count);
-  }
-}
-
-var invalidVersion = function() {
-  return new Buffer([48, 49, 50, 51, 52, 53, 54, 55]);
-};
-
-function notReplaceWithVersion(k, opts) {
-  return function(client) {
-    return client.replaceWithVersion(k, 'ignore', invalidVersion(), opts);
-  }
-}
-
-function removeWithVersion(k, version, opts) {
-  return function(client) {
-    return client.removeWithVersion(k, version, opts);
-  }
-}
-
-function notRemoveWithVersion(k, opts) {
-  return function(client) {
-    return client.removeWithVersion(k, invalidVersion(), opts);
-  }
-}
-
-function expectIteratorDone(it) {
-  return function() {
-    return it.next().then(function(entry) {
-      expect(entry.done).toBeTruthy();
-    })
-  }
-}
-
-function parIterator(batchSize, expected, opts) {
-  return function(client) {
-    return client.iterator(batchSize, opts).then(function(it) {
-      var promises = _.map(_.range(expected.length), function() {
-        return it.next().then(function(entry) { return entry; })
-      });
-      return Promise.all(promises)
-        .then(function(actual) { toContainAll(expected)(actual); })
-        .then(expectIteratorDone(it))
-        .then(expectIteratorDone(it)) // Second time should not go remote
-        .then(function() { return it.close(); }) // Close iterator
-        .then(function() { return client; });
-    })
-  }
-}
-
-function seqIterator(batchSize, expected, opts) {
-  return function(client) {
-    return client.iterator(batchSize, opts).then(function(it) {
-      var p = _.foldl(_.range(expected.length),
-        function(p) {
-          return p.then(function(array) {
-             return it.next().then(function(entry) {
-               array.push(entry);
-               return array;
-             })
-          });
-        }, Promise.resolve([]));
-
-      return p
-          .then(function(array) { toContainAll(expected)(array); })
-          .then(function() { return it.close(); }) // Close iterator
-          .then(function() { return client; });
-    })
-  }
-}
-
-
-function toEqual(value) {
-  return function(actual) {
-    expect(actual).toEqual(value);
-  }
-}
-
-function toEqualPairs(value) {
-  return function(actual) {
-    expect(_.sortBy(actual, 'key')).toEqual(value);
-  }
-}
-
-function toContainAll(expected) {
-  return function(actual) {
-    var sorted = _.sortBy(actual, 'key');
-    var zipped = _.zip(sorted, expected);
-    _.map(zipped, function(e) {
-      var actualEntry = e[0];
-      var expectedEntry = e[1];
-      t.toContain(expectedEntry)(actualEntry);
-    });
-  }
-}
-
-function toBeStatIncr(stat) {
-  return function(before, after) {
-    expect(after[stat]).toBe(before[stat] + 1);
-  }
-}
-
-var failed = function(done) {
-  return function(error) {
-    done(error);
-  };
-};

--- a/spec/protocols_spec.js
+++ b/spec/protocols_spec.js
@@ -27,6 +27,11 @@ describe('Protocols', function() {
   it('can encode/decode max idle', function() {
     encodeDecodeUnits('maxIdle', maxIdle);
   });
+  it('connects with undefined HotRod Protocol', function (done) {
+    t.expectToThrow(function () {
+      t.client(t.local, null, '1.1');
+    }, 'Unknown protocol version: 1.1', done);
+  });
 
   function encodeDecodeUnits(name, converter) {
     var exp = object(name);

--- a/spec/utils/typed-put-get-dist.js
+++ b/spec/utils/typed-put-get-dist.js
@@ -1,0 +1,3 @@
+// mode=distributed,language=javascript,parameters=[k, v],datatype='text/plain; charset=utf-8'
+cache.put(k, v);
+cache.get(k);


### PR DESCRIPTION
The CRUD and entry expiration tests are also ported from local mode to clustered mode. 
The infinispan_local_spec.js is changed so that the tests are run for both available Hotrod Protocol Versions. 
More tests are added verifying the codec.js and funcitonal.js library functions. 

P.S. There are a few tests in infinispan_cluster_spec.js which are disabled due to the bugs reported in the JIRA. 
