### PR TITLE
HRJS-25 pkill kill itself in some envs

### DIFF
--- a/spec/infinispan_failover_spec.js
+++ b/spec/infinispan_failover_spec.js
@@ -1,8 +1,8 @@
 var Promise = require('promise');
 
 var exec = Promise.denodeify(require('child_process').exec);
+var util = require('util');
 
-var f = require('../lib/functional');
 var t = require('./utils/testing'); // Testing dependency
 var u = require('../lib/utils');
 var tests = require('./tests'); // Shared tests
@@ -107,8 +107,7 @@ function launchClusterNode(nodeName, offset) {
 
 function killClusterNode(nodeName) {
   return function(client) {
-    logger.debugf('Kill node: %s', nodeName);
-    return exec("pkill -9 -f '.*java.*" + nodeName + " .*'")
+    return t.pkill(util.format('.*java.*%s .*', nodeName))
       .then(function() { return client; });
   }
 }

--- a/spec/infinispan_xsite_spec.js
+++ b/spec/infinispan_xsite_spec.js
@@ -5,7 +5,6 @@ var Promise = require('promise');
 var exec = Promise.denodeify(require('child_process').exec);
 var util = require('util');
 
-var f = require('../lib/functional');
 var t = require('./utils/testing'); // Testing dependency
 var u = require('../lib/utils');
 var tests = require('./tests'); // Shared tests
@@ -149,16 +148,13 @@ function launchSite(siteName, offset, mcast) {
 
 function killClusterNode(nodeName) {
   return function() {
-    logger.debugf('Kill node: %s', nodeName);
-    return exec("pkill -9 -f '.*java.*" + nodeName + " .*'")
+    return t.pkill(util.format('.*java.*%s .*', nodeName));
   }
 }
 
 function killAll() {
-  logger.debugf('Kill site-a');
-  return exec("pkill -9 -f '.*java.*node-site-a .*'")
+  return t.pkill('.*java.*node-site-a .*')
     .finally(function() {
-      logger.debugf('Kill site-b');
-      return exec("pkill -9 -f '.*java.*node-site-b .*'");
+      return t.pkill('.*java.*node-site-b .*');
     });
 }

--- a/spec/utils/testing.js
+++ b/spec/utils/testing.js
@@ -538,3 +538,11 @@ exports.getClusterMembers = function(mgmtPort) {
     });
   });
 };
+
+exports.pkill = function(pattern) {
+  logger.debugf('Kill: %s', pattern);
+  return exec(util.format("pkill -9 -f '%s'", pattern))
+    .catch(function (err) {
+      logger.debugf('Ignoring `pkill` error: ' + err);
+    })
+};


### PR DESCRIPTION
https://issues.jboss.org/projects/HRJS/issues/HRJS-25

* Workaround it by ignoring any errors that arise from pkill after
  logging them.

@tristantarrant Can you try and see if the pkill errors are gone in your env with this? I could not reproduce.