### PR TITLE
HRJS-18 Parallel iteration tests randomly failing with NoSuchElement exception

### DIFF
--- a/spec/infinispan_cluster_spec.js
+++ b/spec/infinispan_cluster_spec.js
@@ -33,8 +33,12 @@ describe('Infinispan cluster client', function() {
       .catch(t.failed(done)).finally(done);
   });
 
-  it('can iterate over entries in a cluster',
-     tests.iterateEntries('cluster', client)
+  it('can iterate over entries in a cluster, one entry at the time',
+    tests.iterateEntries('cluster', 1, client)
+  );
+
+  it('can iterate over entries in a cluster, more than one entry at the time',
+    tests.iterateEntries('cluster', 3, client)
   );
 
   it('can remove listener in cluster', function(done) { client

--- a/spec/infinispan_local_spec.js
+++ b/spec/infinispan_local_spec.js
@@ -186,8 +186,12 @@ describe('Infinispan local client', function() {
 
   if (process.env.protocol == null || process.env.protocol == '2.5') {
 
-    it('can iterate over entries',
-       tests.iterateEntries('local', client)
+    it('can iterate over entries, one entry at the time',
+       tests.iterateEntries('local', 1, client)
+    );
+
+    it('can iterate over entries, more than one entry at the time',
+      tests.iterateEntries('local', 3, client)
     );
 
     it('can iterate over entries getting their expirable metadata', function (done) {
@@ -196,8 +200,8 @@ describe('Infinispan local client', function() {
         return f.merge(pair, {done: false, lifespan: 86400, maxIdle: 3600});
       });
       client
+          .then(t.assert(t.clear()))
           .then(t.assert(t.putAll(pairs, {lifespan: '1d', maxIdle: '1h'}), t.toBeUndefined))
-          .then(t.parIterator(1, expected, {metadata: true})) // Iterate all data, 1 element at time, parallel
           .then(t.seqIterator(3, expected, {metadata: true})) // Iterate all data, 3 elements at time, sequential
           .catch(t.failed(done))
           .finally(done);

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -12,16 +12,16 @@ exports.execPutGet = function(path, prefix, client, expectFun) {
   }
 };
 
- exports.iterateEntries = function(prefix, client) {
+ exports.iterateEntries = function(prefix, batchSize, client) {
   return function(done) {
     var pairs = [
       {key: prefix + '-it1', value: 'v1', done: false},
       {key: prefix + '-it2', value: 'v2', done: false},
       {key: prefix + '-it3', value: 'v3', done: false}];
     client
+      .then(t.assert(t.clear()))
       .then(t.assert(t.putAll(pairs), t.toBeUndefined))
-      .then(t.parIterator(1, pairs)) // Iterate all data, 1 element at time, parallel
-      .then(t.seqIterator(3, pairs)) // Iterate all data, 3 elements at time, sequential
+      .then(t.seqIterator(batchSize, pairs))
       .catch(t.failed(done))
       .finally(done);
   }

--- a/spec/utils/testing.js
+++ b/spec/utils/testing.js
@@ -407,24 +407,6 @@ exports.expectIteratorDone = function(it) {
   }
 };
 
-exports.parIterator = function(batchSize, expected, opts) {
-  return function(client) {
-    return client.iterator(batchSize, opts).then(function(it) {
-      var promises = _.map(_.range(expected.length), function() {
-        return it.next().then(function(entry) { return entry; })
-      });
-      return Promise.all(promises)
-          .then(function(actual) {
-            exports.toContainAllEntries(expected)(actual);
-          })
-          .then(exports.expectIteratorDone(it))
-          .then(exports.expectIteratorDone(it)) // Second time should not go remote
-          .then(function() { return it.close(); }) // Close iterator
-          .then(function() { return client; });
-    })
-  }
-};
-
 exports.seqIterator = function(batchSize, expected, opts) {
   return function(client) {
     return client.iterator(batchSize, opts).then(function(it) {


### PR DESCRIPTION
Depends on #12.

https://issues.jboss.org/browse/HRJS-18

* Parallel iteration is not a pattern that we promote since you can
never be sure how many parallel iterations should be done.
* Instead, The normal pattern is to get 1 or N entries, depending on the
batch size, and check whether done to ask more entries.
( This should avoid the spurious NoSuchElement exceptions received from
server.