### PR TITLE
HRJS-24 Add stress test and fix error decoding

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -102,16 +102,10 @@
           if (protocol.isEvent(header)) {
             canDecodeMore = protocol.decodeEvent(header, bytebuf);
           } else {
-            var rpc = transport.findRpc(header.msgId);
-            if (f.existy(rpc)) {
-              var body = protocol.isError(header)
-                ? protocol.decodeError(header, bytebuf)
-                : protocol.decodeBody(rpc.decoder, header, bytebuf, conn);
-              canDecodeMore = body.continue;
-              if (body.continue)
-                completeRpc(rpc, header, protocol.isError(header), topology, body);
+            if (protocol.isError(header)) {
+              canDecodeMore = decodeError(header, bytebuf, topology);
             } else {
-              logger.error('Rpc not found for (msgId=%d)', header.msgId);
+              canDecodeMore = decodeRpcBody(header, bytebuf, topology);
             }
           }
 
@@ -122,6 +116,37 @@
         } else {
           rewind(); // Incomplete topology, rewind
         }
+      }
+    }
+
+    function decodeError(header, bytebuf, topology) {
+      var protocol = transport.getProtocol();
+      var body = protocol.decodeError(header, bytebuf);
+      var canDecodeMore = body.continue;
+      if (body.continue) {
+        var rpc = transport.findRpc(header.msgId);
+        if (f.existy(rpc)) {
+          completeRpc(rpc, header, true, topology, body);
+        } else {
+          logger.error('Error received but rpc not found for (msgId=%d)', header.msgId);
+        }
+      }
+      return canDecodeMore;
+    }
+
+    function decodeRpcBody(header, bytebuf, topology) {
+      var protocol = transport.getProtocol();
+      var rpc = transport.findRpc(header.msgId);
+      if (f.existy(rpc)) {
+        var body = protocol.decodeBody(rpc.decoder, header, bytebuf, conn);
+        var canDecodeMore = body.continue;
+        if (body.continue)
+          completeRpc(rpc, header, protocol.isError(header), topology, body);
+
+        return canDecodeMore;
+      } else {
+        logger.error('Rpc not found for (msgId=%d)', header.msgId);
+        return true;
       }
     }
 
@@ -210,7 +235,10 @@
         });
       },
       write: function(buffer) {
-        sock.write(buffer);
+        var flushed = sock.write(buffer);
+        if (!flushed)
+          logger.debugf('Buffer write not fully flushed, part of of data queued for: %s',
+            buffer.toString('hex').toUpperCase());
       },
       getAddress: function() {
         return addr;

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -257,7 +257,7 @@
       },
       decodeError: function(header, bytebuf) {
         var msg = DECODE_STRING(bytebuf);
-        logger.error('Error decoding body of request(msgId=%d):', header.msgId, msg);
+        logger.error('Error decoding body of request(msgId=%d): %s', header.msgId, msg);
         return {continue: true, result: msg};
       },
       decodeBody: function(decoder, header, bytebuf, conn) {

--- a/spec/configs/domain.xml
+++ b/spec/configs/domain.xml
@@ -72,6 +72,9 @@
                 <logger category="com.arjuna">
                     <level name="WARN"/>
                 </logger>
+                <logger category="org.infinispan">
+                    <level name="TRACE"/>
+                </logger>
                 <logger category="org.jboss.as.config">
                     <level name="DEBUG"/>
                 </logger>
@@ -390,15 +393,6 @@
                             <write-behind modification-queue-size="1024" thread-pool-size="1"/>
                         </string-keyed-jdbc-store>
                     </distributed-cache-configuration>
-                    <distributed-cache-configuration name="persistent-jdbc-binary-keyed" mode="SYNC" owners="2" start="EAGER">
-                        <binary-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="true" purge="false" shared="false" passivation="false">
-                            <binary-keyed-table prefix="ISPN">
-                                <id-column name="id" type="VARCHAR"/>
-                                <data-column name="datum" type="BINARY"/>
-                                <timestamp-column name="version" type="BIGINT"/>
-                            </binary-keyed-table>
-                        </binary-keyed-jdbc-store>
-                    </distributed-cache-configuration>
                     <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">
                         <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>
                         <transaction mode="NONE"/>
@@ -695,15 +689,6 @@
                             </string-keyed-table>
                             <write-behind modification-queue-size="1024" thread-pool-size="1"/>
                         </string-keyed-jdbc-store>
-                    </distributed-cache-configuration>
-                    <distributed-cache-configuration name="persistent-jdbc-binary-keyed" mode="SYNC" owners="2" start="EAGER">
-                        <binary-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="true" purge="false" shared="false" passivation="false">
-                            <binary-keyed-table prefix="ISPN">
-                                <id-column name="id" type="VARCHAR"/>
-                                <data-column name="datum" type="BINARY"/>
-                                <timestamp-column name="version" type="BIGINT"/>
-                            </binary-keyed-table>
-                        </binary-keyed-jdbc-store>
                     </distributed-cache-configuration>
                     <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">
                         <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>
@@ -1009,15 +994,6 @@
                             </string-keyed-table>
                             <write-behind modification-queue-size="1024" thread-pool-size="1"/>
                         </string-keyed-jdbc-store>
-                    </distributed-cache-configuration>
-                    <distributed-cache-configuration name="persistent-jdbc-binary-keyed" mode="SYNC" owners="2" start="EAGER">
-                        <binary-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="true" purge="false" shared="false" passivation="false">
-                            <binary-keyed-table prefix="ISPN">
-                                <id-column name="id" type="VARCHAR"/>
-                                <data-column name="datum" type="BINARY"/>
-                                <timestamp-column name="version" type="BIGINT"/>
-                            </binary-keyed-table>
-                        </binary-keyed-jdbc-store>
                     </distributed-cache-configuration>
                     <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">
                         <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>

--- a/spec/infinispan_stress_spec.js
+++ b/spec/infinispan_stress_spec.js
@@ -1,0 +1,35 @@
+var _ = require('underscore');
+var Promise = require('promise');
+
+var f = require('../lib/functional');
+var t = require('./utils/testing'); // Testing dependency
+var tests = require('./tests'); // Shared tests
+
+describe('Infinispan local client under stress load', function() {
+  var client = t.client(t.local);
+
+  beforeEach(function(done) { client
+    .then(t.assert(t.clear()))
+    .catch(t.failed(done)).finally(done);
+  });
+
+  it('can do multiple puts continuously and only wait at the end', function(done) {
+    client.then(function(cl) {
+      var puts = _.map(_.range(1000), function(i) {
+        return cl.put(i + '', i + '');
+      });
+
+      return Promise.all(puts)
+        .catch(t.failed(done))
+        .finally(done);
+    })
+  });
+
+  // Since Jasmine 1.3 does not have afterAll callback, this disconnect test must be last
+  it('disconnects client', function(done) { client
+    .then(t.disconnect())
+    .catch(t.failed(done))
+    .finally(done);
+  });
+
+});

--- a/spec/utils/testing.js
+++ b/spec/utils/testing.js
@@ -365,7 +365,7 @@ exports.findKeyForServers = function(client, addrs) {
   } while (!_.isEqual(addrs, owners) && attempts >= 0);
 
   if (attempts < 0)
-    throw new Error("Could not find any key owned by: " + addrs);
+    throw new Error("Could not find any key owned by: " + u.showArrayAddress(addrs));
 
   logger.debugf("Generated key=%s hashing to %s", key, u.showArrayAddress(addrs));
   return key;


### PR DESCRIPTION
Depends on PR #16 and Will's Infinispan fix to address replay issues (see [here](https://github.com/infinispan/infinispan/pull/4771)).

I have verified that Will's patch makes the stress test pass, but since that required building master snapshot, as already highlighted in PR #16, new failures appear with master snapshot:

```
  1) Infinispan cluster client can remove listener in cluster
   Message:
     timeout: timed out after 5000 msec waiting for spec to complete
   Stacktrace:
     undefined

  2) Infinispan local client working with expiry operations removes keys when their max idle time has expired in cluster
   Message:
     timeout: timed out after 5000 msec waiting for spec to complete
   Stacktrace:
     undefined

Finished in 41.371 seconds
144 tests, 561 assertions, 2 failures, 0 skipped
```