### PR TITLE
HRJS-75 Update Hot Rod 2.9 protocol support

### DIFF
--- a/lib/infinispan.js
+++ b/lib/infinispan.js
@@ -595,7 +595,7 @@
       ping: function() {
         var ctx = u.context(TINY);
         logger.debugf('Invoke ping(msgId=%d)', ctx.id);
-        return futureEmpty(ctx, 0x17);
+        return futureDecodeOnly(ctx, 0x17, p.decodeServerMediaTypes);
       },
       /**
        * Statistic item.

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -786,6 +786,22 @@
         , codec.encodeUByte(0)
       ];
     }
+
+    function decodeServerMediaType(bytebuf) {
+      var mediaType = DECODE_UBYTE(bytebuf);
+      if (!f.existy(mediaType))
+        return {continue: false};
+
+      if (_.isEqual(mediaType, 1)) {
+        var decodePredefinedMediaType =
+          f.actions([codec.decodeUByte(), codec.decodeVInt()], codec.allDecoded(2));
+        var predefinedMediaType = decodePredefinedMediaType(bytebuf);
+        if (!f.existy(predefinedMediaType))
+          return {continue: false};
+      }
+
+      return {continue: true};
+    }
     
     return {
       init: function(clientOpts) {
@@ -816,6 +832,16 @@
       },
       getValueMediaType: function() {
         return this.valueMediaType.getMediaType();
+      },
+      decodeServerMediaTypes: function(header, bytebuf) {
+        var keyMediaType = decodeServerMediaType(bytebuf);
+        if (keyMediaType.continue) {
+          var valueMediaType = decodeServerMediaType(bytebuf);
+          if (valueMediaType.continue)
+            return {result: undefined, continue: true};
+        }
+
+        return {continue: false};
       }
     }
   }());

--- a/run-domain.sh
+++ b/run-domain.sh
@@ -9,7 +9,7 @@ else
 fi
 
 
-SERVER_VERSION="9.4.0.CR1"
+SERVER_VERSION="9.4.0.CR2"
 SERVER_HOME=server/infinispan-server-$SERVER_VERSION
 CLUSTER_SIZE_MAIN="/host=master/server=server-three/subsystem=datagrid-infinispan/cache-container=clustered:read-attribute(name=cluster-size)"
 ZIP_ROOT="http://downloads.jboss.org/infinispan"


### PR DESCRIPTION
https://issues.jboss.org/browse/HRJS-75

* Infinispan 9.4.0.CR2, which includes Hot Rod 2.9 protocol now
  returns key/value media types on ping instead of relying on
  compatibility information on status numbers.