### PR TITLE
HRJS-83 Add client listener failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,14 @@ fashion, regardless of whether they are key-based or multi-key/key-less.
 The routing and failover is transparent to the user code, so the operations
 executed against in a cluster look exactly the same as in the previous code 
 examples.
- 
+
+When a connection with a server breaks,
+incomplete operations are retried in other servers in the cluster.
+
+If a server that has a client listener registered fails or leaves the cluster,
+the client transparently migrates the listener registration to another node in the cluster.
+By doing so, the client can continue receiving events in the presence of failures or topology changes.
+
 You can run a test locally by starting multiple instances of Infinispan 
 Server like this:
 

--- a/lib/infinispan.js
+++ b/lib/infinispan.js
@@ -15,6 +15,7 @@
   var u = require('./utils');
   var protocols = require('./protocols');
   var io = require('./io');
+  var listeners = require('./listeners');
 
   var Client = function(addrs, clientOpts) {
     var logger = u.logger('client');
@@ -31,54 +32,39 @@
     }
 
     var p = protocolResolver(clientOpts['version']);
+    var listen = listeners(p);
 
     var TINY = 16, SMALL = 32, MEDIUM = 64, BIG = 128;
 
-    var transport = io(addrs, p, clientOpts);
-
-    function stepsHeader(ctx, op, opts) {
-      var header = p.encodeHeader(op, transport.getTopologyId(), opts)(ctx.id);
-      var mediaType = p.encodeMediaTypes();
-      return f.cat(header, mediaType);
-    }
-
-    function stepsHeaderBody(ctx, op, body, opts) {
-      var header = stepsHeader(ctx, op, opts);
-      return f.cat(header, body(opts));
-    }
+    var transport = io(addrs, p, clientOpts, listen);
 
     function future(ctx, op, body, decoder, opts) {
-      f.actions(stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
+      f.actions(p.stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
       return transport.writeCommand(ctx, decoder);
     }
 
-    function futurePreWrite(ctx, op, body, decoder, opts, preWrite) {
-      f.actions(stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
-      return transport.writeCommand(ctx, decoder, preWrite);
-    }
-
     function futureDecodeOnly(ctx, op, decoder, opts) {
-      f.actions(stepsHeader(ctx, op, opts), codec.bytesEncoded)(ctx);
+      f.actions(p.stepsHeader(ctx, op, opts), codec.bytesEncoded)(ctx);
       return transport.writeCommand(ctx, decoder);
     }
 
     function futureEmpty(ctx, op) {
-      f.actions(stepsHeader(ctx, op), codec.bytesEncoded)(ctx);
+      f.actions(p.stepsHeader(ctx, op), codec.bytesEncoded)(ctx);
       return transport.writeCommand(ctx);
     }
 
     function futureKey(ctx, op, key, body, decoder, opts) {
-      f.actions(stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
+      f.actions(p.stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
       return transport.writeKeyCommand(ctx, key, decoder);
     }
 
     function futurePinned(ctx, op, body, decoder, conn) {
-      f.actions(stepsHeaderBody(ctx, op, body), codec.bytesEncoded)(ctx);
+      f.actions(p.stepsHeaderBody(ctx, op, body), codec.bytesEncoded)(ctx);
       return transport.writeCommandPinned(ctx, decoder, conn);
     }
 
     function futureExec(ctx, op, body, decoder, opts) {
-      f.actions(stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
+      f.actions(p.stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
       var resultPromise = transport.writeCommand(ctx, decoder);
       return resultPromise.then(function(result) {
         var skipNull = result.replace(/null/g, '\"\"');
@@ -142,7 +128,7 @@
             logger.tracef('Iterator(iteratorId=%s) already exhausted', iterId);
             return donePromise();
           } else if (_.isEmpty(nextElems)) {
-            var ctx = u.context(SMALL);
+            var ctx = transport.context(SMALL);
             logger.tracef(
                 'Invoke iterator.next(msgId=%d,iteratorId=%s) on %s'
                 , ctx.id, iterId, conn.toString()
@@ -172,50 +158,11 @@
          * @since 0.3
          */
         close: function() {
-          var ctx = u.context(SMALL);
+          var ctx = transport.context(SMALL);
           logger.debugf('Invoke iterator.close(msgId=%d,iteratorId=%s) on %s', ctx.id, iterId, conn.toString());
           return futurePinned(
               ctx, 0x35, p.encodeIterId(iterId), p.complete(p.hasSuccess), conn);
         }
-      }
-    }
-
-    function addLocalListener(ctx, event, listener, opts) {
-      logger.debugl(function() { return ['Invoke addListener(msgId=%d,event=%s,opts=%s) locally',
-                                         ctx.id, event, JSON.stringify(opts)]; });
-      return new Promise(function (fulfill, reject) {
-        p.addListener(event, listener, opts.listenerId);
-        fulfill(opts.listenerId);
-      });
-    }
-
-    function addRemoteListener(ctx, event, listener, opts) {
-      var listenerId = _.uniqueId('listener_');
-      logger.debugl(function() {
-          return ['Invoke addListener(msgId=%d,event=%s,listenerId=%s,opts=%s) remotely',
-              ctx.id, event, listenerId, JSON.stringify(opts)]; });
-
-      var encodeListenerAddCommon = p.encodeListenerAdd(listenerId, opts)();
-      var encodeListenerAddInterests = p.encodeListenerInterests(opts);
-      var encodeListenerAdd = function() {
-        return f.cat(encodeListenerAddCommon, encodeListenerAddInterests);
-      };
-
-      var remote = futurePreWrite(ctx, 0x25
-          , encodeListenerAdd, p.complete(p.hasSuccess)
-          , opts, preWriteAddListener(event, listener, listenerId));
-      return remote
-        .then(function(success) { return success ? listenerId : p.removeListeners(listenerId); })
-        .catch(function() { p.removeListeners(listenerId); });
-    }
-
-    function preWriteAddListener(event, listener, listenerId) {
-      return function(conn) {
-        // Listener needs to be registered in advance since events might come
-        // before reply from server to add listener, e.g. when include state
-        // is enabled. To avoid leaking listeners, remove listener if there's
-        // any problem.
-        p.addListener(event, listener, listenerId, conn);
       }
     }
 
@@ -253,7 +200,7 @@
        * @since 0.3
        */
       get: function(k) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugf('Invoke get(msgId=%d,key=%s)', ctx.id, u.str(k));
         var decoder = p.decodeValue();
         return futureKey(ctx, 0x03, k, p.encodeKey(k), decoder);
@@ -269,7 +216,7 @@
        * @since 0.3
        */
       containsKey: function(k) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugf('Invoke containsKey(msgId=%d,key=%s)', ctx.id, u.str(k));
         return futureKey(ctx, 0x0F, k, p.encodeKey(k), p.complete(p.hasSuccess));
       },
@@ -296,7 +243,7 @@
        * @since 0.3
        */
       getWithMetadata: function(k) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugf('Invoke getWithMetadata(msgId=%d,key=%s)', ctx.id, u.str(k));
         var decoder = p.decodeWithMeta();
         return futureKey(ctx, 0x1B, k, p.encodeKey(k), decoder);
@@ -340,7 +287,7 @@
        * @since 0.3
        */
       put: function(k, v, opts) {
-        var ctx = u.context(MEDIUM);
+        var ctx = transport.context(MEDIUM);
         logger.debugl(function() { return ['Invoke put(msgId=%d,key=%s,value=%s,opts=%s)',
                                            ctx.id, u.str(k), u.str(v), u.str(opts)]; });
         var decoder = p.decodePrevOrElse(opts, p.hasSuccess, p.complete(_.constant(undefined)));
@@ -370,7 +317,7 @@
        * @since 0.3
        */
       remove: function(k, opts) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugl(function() {return ['Invoke remove(msgId=%d,key=%s,opts=%s)',
                                           ctx.id, u.str(k), JSON.stringify(opts)]; });
         var decoder = p.decodePrevOrElse(opts, p.hasSuccess, p.complete(p.hasSuccess));
@@ -392,7 +339,7 @@
        * @since 0.3
        */
       putIfAbsent: function(k, v, opts) {
-        var ctx = u.context(MEDIUM);
+        var ctx = transport.context(MEDIUM);
         logger.debugl(function() {return ['Invoke putIfAbsent(msgId=%d,key=%s,value=%s,opts=%s)',
                                           ctx.id, u.str(k), u.str(v), JSON.stringify(opts)]; });
         var decoder = p.decodePrevOrElse(opts, p.hasNotExecuted, p.complete(p.hasSuccess));
@@ -414,7 +361,7 @@
        * @since 0.3
        */
       replace: function(k, v, opts) {
-        var ctx = u.context(MEDIUM);
+        var ctx = transport.context(MEDIUM);
         logger.debugl(function() { return ['Invoke replace(msgId=%d,key=%s,value=%s,opts=%s)',
                                            ctx.id, u.str(k), u.str(v), JSON.stringify(opts)]; });
         var decoder = p.decodePrevOrElse(opts, p.hasPrevious, p.complete(p.hasSuccess));
@@ -443,7 +390,7 @@
        * @since 0.3
        */
       replaceWithVersion: function(k, v, version, opts) {
-        var ctx = u.context(MEDIUM);
+        var ctx = transport.context(MEDIUM);
         logger.debugl(function() { return ['Invoke replaceWithVersion(msgId=%d,key=%s,value=%s,version=0x%s,opts=%s)',
                                            ctx.id, u.str(k), u.str(v), version.toString('hex'), JSON.stringify(opts)]; });
         var decoder = p.decodePrevOrElse(opts, p.hasPrevious, p.complete(p.hasSuccess));
@@ -471,7 +418,7 @@
        * @since 0.3
        */
       removeWithVersion: function(k, version, opts) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugl(function() { return ['Invoke removeWithVersion(msgId=%d,key=%s,version=0x%s,opts=%s)',
                                            ctx.id, u.str(k), version.toString('hex'), JSON.stringify(opts)]; });
         var decoder = p.decodePrevOrElse(opts, p.hasPrevious, p.complete(p.hasSuccess));
@@ -497,7 +444,7 @@
        * @since 0.3
        */
       getAll: function(keys) {
-        var ctx = u.context(MEDIUM);
+        var ctx = transport.context(MEDIUM);
         logger.debugf('Invoke getAll(msgId=%d,keys=%s)', ctx.id, u.str(keys));
         // TODO: Validate empty keys
         return future(ctx, 0x2F, p.encodeMultiKey(keys), p.decodeCountValues());
@@ -525,7 +472,7 @@
        * @since 0.3
        */
       putAll: function(pairs, opts) {
-        var ctx = u.context(BIG);
+        var ctx = transport.context(BIG);
         logger.debugl(function() { return ['Invoke putAll(msgId=%d,pairs=%s,opts=%s)',
                                            ctx.id, JSON.stringify(pairs), JSON.stringify(opts)]; });
         return future(ctx, 0x2D, p.encodeMultiKeyValue(pairs), p.complete(_.constant(undefined)), opts);
@@ -553,7 +500,7 @@
        * @since 0.3
        */
       iterator: function(batchSize, opts) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugf('Invoke iterator(msgId=%d,batchSize=%d,opts=%s)', ctx.id, batchSize, u.str(opts));
         var remote = future(ctx, 0x31, p.encodeIterStart(batchSize, opts), p.decodeIterId);
         return remote.then(function(result) {
@@ -569,7 +516,7 @@
        * @since 0.3
        */
       size: function() {
-        var ctx = u.context(TINY);
+        var ctx = transport.context(TINY);
         logger.debugf('Invoke size(msgId=%d)', ctx.id);
         return futureDecodeOnly(ctx, 0x29, p.decodeVInt);
       },
@@ -582,7 +529,7 @@
        * @since 0.3
        */
       clear: function() {
-        var ctx = u.context(TINY);
+        var ctx = transport.context(TINY);
         logger.debugf('Invoke clear(msgId=%d)', ctx.id);
         return futureEmpty(ctx, 0x13);
       },
@@ -595,7 +542,7 @@
        * @since 0.3
        */
       ping: function() {
-        var ctx = u.context(TINY);
+        var ctx = transport.context(TINY);
         logger.debugf('Invoke ping(msgId=%d)', ctx.id);
         return futureDecodeOnly(ctx, 0x17, p.decodeServerMediaTypes);
       },
@@ -621,7 +568,7 @@
        * @since 0.3
        */
       stats: function() {
-        var ctx = u.context(TINY);
+        var ctx = transport.context(TINY);
         logger.debugf('Invoke stats(msgId=%d)', ctx.id);
         return futureDecodeOnly(ctx, 0x15, p.decodeStringPairs);
       },
@@ -655,10 +602,10 @@
        * @since 0.3
        */
       addListener: function(event, listener, opts) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         return _.has(opts, 'listenerId')
-            ? addLocalListener(ctx, event, listener, opts)
-            : addRemoteListener(ctx, event, listener, opts);
+            ? listen.addLocalListener(ctx, event, listener, opts)
+            : listen.addRemoteListener(transport, ctx, event, listener, opts);
       },
       /**
        * Remove an event listener.
@@ -671,9 +618,9 @@
        * @since 0.3
        */
       removeListener: function(listenerId) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugf('Invoke removeListener(msgId=%d,listenerId=%s) remotely', ctx.id, listenerId);
-        var conn = p.findConnectionListener(listenerId);
+        var conn = listen.findConnectionListener(listenerId);
         if (!f.existy(conn))
           return Promise.reject(
             new Error('No server connection for listener (listenerId=' + listenerId + ')'));
@@ -681,7 +628,7 @@
         var remote = futurePinned(ctx, 0x27, p.encodeListenerId(listenerId), p.complete(p.hasSuccess), conn);
         return remote.then(function (success) {
           if (success) {
-            p.removeListeners(listenerId);
+            listen.removeListeners(listenerId);
             return true;
           }
           return false;
@@ -731,7 +678,7 @@
        * @since 0.3
        */
       execute: function(scriptName, params) {
-        var ctx = u.context(SMALL);
+        var ctx = transport.context(SMALL);
         logger.debugf('Invoke execute(msgId=%d,scriptName=%s,params=%s)', ctx.id, scriptName, u.str(params));
         // TODO update jsdoc, value does not need to be String, can be JSON too
         return futureExec(ctx, 0x2B, p.encodeNameParams(scriptName, params), p.decodeValue());

--- a/lib/io.js
+++ b/lib/io.js
@@ -25,7 +25,7 @@
     return ["[", _.map(conns, function(c) { return c.toString(); }).join(","), "]"].join('');
   }
 
-  var Connection = function(addr, transport) {
+  var Connection = function(addr, transport, listeners) {
     var id = _.uniqueId('conn_');
     var logger = u.logger(transport.getId() + '_' + id);
     var sock = new net.Socket();
@@ -118,7 +118,7 @@
 
           if (canDecodeMore) {
             if (protocol.isEvent(header)) {
-              canDecodeMore = protocol.decodeEvent(header, bytebuf);
+              canDecodeMore = protocol.decodeEvent(header, bytebuf, listeners);
             } else {
               if (protocol.isError(header)) {
                 canDecodeMore = decodeError(header, bytebuf, topology);
@@ -339,10 +339,13 @@
           return _.where(addrs, conn.getAddress()).length > 0;
         });
       },
-      disconnect: function(topology) {
-        var missing = f.existy(topology) ? filterNot(topology.servers) : conns;
-        logger.debugf('Disconnect all router connections: %s', showArrayConnections(conns));
-        var disconnects = _.map(missing, function(c) { return c.disconnect(); });
+      getMissingConnections: function(topology) {
+        return filterNot(topology.servers);
+      },
+      disconnect: function(missing) {
+        var connections = f.existy(missing) ? missing : conns;
+        logger.debugf('Disconnect all router connections: %s', showArrayConnections(connections));
+        var disconnects = _.map(connections, function(c) { return c.disconnect(); });
         return Promise.all(disconnects);
       },
       findOwners: function(k, protocol) {
@@ -379,10 +382,14 @@
         });
         return _.isEmpty(found) ? [] : [conn];
       },
-      disconnect: function(topology) {
-        if (f.existy(topology)) {
-          var addrs = topology.servers;
-          var isMissing = isMemberMissing(addrs);
+      getMissingConnections: function(topology) {
+        var addrs = topology.servers;
+        var isMissing = isMemberMissing(addrs);
+        return isMissing ? [conn] : [];
+      },
+      disconnect: function(missing) {
+        if (f.existy(missing)) {
+          var isMissing = !_.isEmpty(missing);
           if (isMissing) {
             logger.debugf('Removed server is: %s', conn.toString());
             return conn.disconnect()
@@ -403,7 +410,7 @@
     }
   };
 
-  function transport(addrs, protocol, clientOpts) {
+  function transport(addrs, protocol, clientOpts, listeners) {
     var id = _.uniqueId('io_');
     var logger = u.logger(id);
     var rpcMap = u.keyValueMap();
@@ -509,31 +516,52 @@
         topology.id, u.showArrayAddress(newAddrs)] });
 
       // Disconnect connections for members not present in topology
-      var disconnectMany = router.disconnect(topology);
+      var missing = router.getMissingConnections(topology);
+      var disconnectMany = router.disconnect(missing);
       // Filter new addresses for which connections need to be created
       var added = filterAdded(topology);
       // Filter connections which continue connected
       var connected = filterConnected(topology);
 
       // Then, create new connections for all added members
-      var newConnected = disconnectMany.then(function() {
-        return Promise.all(_.map(added, function(addr) {
-          return new Connection(addr, transport).connect();
+      var newConnected = disconnectMany.then(function () {
+        return Promise.all(_.map(added, function (addr) {
+          return new Connection(addr, transport, listeners).connect();
         }));
       });
       // Then, join these with the connected members and install new router
-      return newConnected.then(function(newConnects) {
-        var cons = f.cat(router.filter(connected), newConnects);
-        var newRouter = new ConsistentHashRouter(
-          logger, topology.id, cons, topology.segments, router.getClusterName());
-        emitter.emit('router', newRouter);
-      });
+      return newConnected
+        .then(function (newConnects) {
+          var cons = f.cat(router.filter(connected), newConnects);
+          var newRouter = new ConsistentHashRouter(
+            logger, topology.id, cons, topology.segments, router.getClusterName());
+          emitter.emit('router', newRouter);
+        })
+        .then(failoverListeners(transport, missing));
+    }
+
+    function failoverListeners(transport, missing) {
+      return function() {
+        logger.debugf("Failover listeners registered in: %s", showArrayConnections(missing));
+
+        var failover = _.map(missing, function(c) {
+          var listenersAt = listeners.getListenersAt(c.getAddress());
+
+          return _.map(listenersAt, function(listener) {
+            logger.debugf("Failover listener with id: %s", listener.id);
+            listeners.removeListeners(listener.id);
+            return listeners.addRemoteListener(transport, transport.context(32), listener.event, listener.callback);
+          });
+        });
+
+        return Promise.all(_.flatten(failover));
+      }
     }
 
     function toLazyConnections(servers, connF, transport) {
       return _.map(servers, function(server) {
         return function() {
-          var conn = new Connection(server, transport);
+          var conn = new Connection(server, transport, listeners);
           return connF(conn);
         };
       });
@@ -744,6 +772,11 @@
       },
       getId: function() {
         return id;
+      },
+      context: function(size) {
+        var ctx = u.context(size);
+        ctx.topologyId = this.getTopologyId();
+        return ctx;
       }
     };
     return o;

--- a/lib/listeners.js
+++ b/lib/listeners.js
@@ -1,0 +1,112 @@
+'use strict';
+
+(function() {
+
+  var _ = require('underscore');
+  var f = require('./functional');
+  var u = require('./utils');
+
+  var codec = require('./codec');
+
+  var events = require('events');
+
+  module.exports = listeners;
+
+  function listeners(protocol) {
+    var logger = u.logger('listeners');
+    var listeners = u.keyValueMap();
+
+    function futurePreWrite(transport, ctx, op, body, decoder, opts, preWrite) {
+      f.actions(protocol.stepsHeaderBody(ctx, op, body, opts), codec.bytesEncoded)(ctx);
+      return transport.writeCommand(ctx, decoder, preWrite);
+    }
+
+    function preWriteAddListener(event, listener, listenerId) {
+      return function(conn) {
+        // Listener needs to be registered in advance since events might come
+        // before reply from server to add listener, e.g. when include state
+        // is enabled. To avoid leaking listeners, remove listener if there's
+        // any problem.
+        emitterAddListener(event, listener, listenerId, conn);
+      }
+    }
+
+    function createEmitter(listenerId, conn, event, callback) {
+      var emitter = new events.EventEmitter();
+      logger.tracef('Create listener emitter for connection %s and listener with listenerId=%s', conn, listenerId);
+      listeners.put(listenerId, {emitter: emitter, conn: conn, event: event, callback: callback});
+      return emitter;
+    }
+
+    function emitterAddListener(event, callback, listenerId, conn) {
+      var l = listeners.get(listenerId);
+      var emitter = f.existy(l) ? l.emitter : createEmitter(listenerId, conn, event, callback);
+      emitter.addListener(event, callback);
+    }
+
+    var listen = {
+      removeListeners: function(listenerId) {
+        var l = listeners.get(listenerId);
+        if (f.existy(l)) {
+          l.emitter.removeAllListeners();
+          listeners.remove(listenerId);
+        }
+      },
+      findConnectionListener: function(listenerId) {
+        var l = listeners.get(listenerId);
+        return f.existy(l) ? l.conn : undefined;
+      },
+      addRemoteListener: function (transport, ctx, event, listener, opts) {
+        var listenerId = _.uniqueId('listener_');
+        logger.debugl(function() {
+          return ['Invoke addListener(msgId=%d,event=%s,listenerId=%s,opts=%s) remotely',
+                  ctx.id, event, listenerId, JSON.stringify(opts)]; });
+
+        var encodeListenerAddCommon = protocol.encodeListenerAdd(listenerId, opts)();
+        var encodeListenerAddInterests = protocol.encodeListenerInterests(opts);
+        var encodeListenerAdd = function() {
+          return f.cat(encodeListenerAddCommon, encodeListenerAddInterests);
+        };
+
+        var remote = futurePreWrite(transport, ctx, 0x25
+          , encodeListenerAdd, protocol.complete(protocol.hasSuccess)
+          , opts, preWriteAddListener(event, listener, listenerId));
+
+        return remote
+          .then(function(success) {
+            return success ? listenerId : protocol.removeListeners(listenerId);
+          })
+          .catch(function() {
+            protocol.removeListeners(listenerId);
+          });
+      },
+      addLocalListener: function (ctx, event, listener, opts) {
+        logger.debugl(function() {
+          return ['Invoke addListener(msgId=%d,event=%s,opts=%s) locally',
+                  ctx.id, event, JSON.stringify(opts)]; });
+
+        return new Promise(function (fulfill) {
+          emitterAddListener(event, listener, opts.listenerId);
+          fulfill(opts.listenerId);
+        });
+      },
+      dispatchEvent: function(event, listenerId, bytebuf, emitFunc) {
+        return function() {
+          var l = listeners.get(listenerId);
+          if (f.existy(l))
+            return emitFunc(event, l.emitter, bytebuf, listenerId);
+
+          logger.error('No emitter exists for listener %s', listenerId);
+          return true;
+        }
+      },
+      getListenersAt: function (addr) {
+        return _.filter(listeners.values(), function(listener) {
+          return _.isEqual(addr, listener.conn.getAddress());
+        });
+      },
+    };
+    return listen;
+  }
+
+}.call(this));

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -172,8 +172,17 @@
           });
           return steps;
         };
+      },
+      stepsHeader: function(ctx, op, opts) {
+        var header = this.encodeHeader(op, ctx.topologyId, opts)(ctx.id);
+        var mediaType = this.encodeMediaTypes();
+        return f.cat(header, mediaType);
+      },
+      stepsHeaderBody: function(ctx, op, body, opts) {
+        var header = this.stepsHeader(ctx, op, opts, ctx.topologyId);
+        return f.cat(header, body(opts));
       }
-    };
+  };
   }());
 
   var ExpiryEncodeMixin = (function() {
@@ -478,9 +487,7 @@
   }());
 
   var ListenersMixin = (function() {
-    var events = require('events');
-    var listeners = u.keyValueMap();
-    var logger = u.logger('listener');
+    var logger = u.logger('protocols.listeners');
 
     var DECODE_EVENT_COMMON = f.actions(
         [codec.decodeString(),      // listener id
@@ -494,17 +501,6 @@
 
           return {listenerId: values[0], isCustom: values[1] == 1, isRetried: values[2] == 1}
         });
-
-    function dispatchEvent(event, listenerId, bytebuf, emitFunc) {
-      return function() {
-        var l = listeners.get(listenerId);
-        if (f.existy(l))
-          return emitFunc(event, l.emitter, bytebuf, listenerId);
-
-        logger.error('No emitter exists for listener %s', listenerId);
-        return true;
-      }
-    }
 
     function emitCustomOr(isCustom, decoderBytes, alternativeEmit) {
       if (isCustom) {
@@ -540,7 +536,7 @@
         var decoder = f.actions(
           [decoderKey.fun(decoderKey.obj), codec.decodeFixedBytes(8)]
           , function(values) {
-              return {key: values[0], version: values[1]};
+            return {key: values[0], version: values[1]};
           }
         );
         var keyVersion = decoder(bytebuf);
@@ -564,19 +560,7 @@
       }
     }
 
-    function createEmitter(listenerId, conn) {
-      var emitter = new events.EventEmitter();
-      logger.tracef('Create listener emitter for connection %s and listener with listenerId=%s', conn, listenerId);
-      listeners.put(listenerId, {emitter: emitter, conn: conn});
-      return emitter;
-    }
-
     return {
-      addListener: function(event, listener, listenerId, conn) {
-        var l = listeners.get(listenerId);
-        var emitter = f.existy(l) ? l.emitter : createEmitter(listenerId, conn);
-        emitter.addListener(event, listener);
-      },
       findConnectionListener: function(listenerId) {
         var l = listeners.get(listenerId);
         return f.existy(l) ? l.conn : undefined;
@@ -615,7 +599,7 @@
           return [codec.encodeString(listenerId)];     // listener id
         }
       },
-      decodeEvent: function(header, bytebuf) {
+      decodeEvent: function(header, bytebuf, listeners) {
         var common = DECODE_EVENT_COMMON(bytebuf);
         if (!f.existy(common))
             return false;
@@ -624,10 +608,10 @@
         if (f.existy(listenerId)) {
           var decoderKey = decoderMedia(this.keyMediaType);
           var dispatcher = f.dispatch(
-              f.isa(0x60, dispatchEvent('create', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKeyVersion))),
-              f.isa(0x61, dispatchEvent('modify', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKeyVersion))),
-              f.isa(0x62, dispatchEvent('remove', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKey))),
-              f.isa(0x63, dispatchEvent('expiry', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKey)))
+              f.isa(0x60, listeners.dispatchEvent('create', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKeyVersion))),
+              f.isa(0x61, listeners.dispatchEvent('modify', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKeyVersion))),
+              f.isa(0x62, listeners.dispatchEvent('remove', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKey))),
+              f.isa(0x63, listeners.dispatchEvent('expiry', listenerId, bytebuf, emitCustomOr(common.isCustom, decoderKey, emitKey)))
           );
           return dispatcher(header.opCode);
         }


### PR DESCRIPTION
* Failover client listeners when nodes with listeners registered leave.
* With the addition of client listener failover,
not only are listeners added by the end user,
but also internally as a result of a failover.
* Hence, it's necessary to separate the listener registration logic,
so that it's easy to invoke it from both places.
* Besides, protocols was not meant to maintain listener state.