### PR TITLE
Fixed clustered configuration and replaced lsof with fuser.

### DIFF
--- a/spec/configs/infinispan-clustered.xml
+++ b/spec/configs/infinispan-clustered.xml
@@ -6,7 +6,7 @@
         xmlns:server="urn:infinispan:server:10.0">
 
     <cache-container name="clustered" default-cache="default">
-        <transport lock-timeout="60000"/>
+        <transport cluster="${infinispan.cluster.name}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
         <!--<global-state/>-->
         <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="1000" striping="false"/>

--- a/spec/utils/testing.js
+++ b/spec/utils/testing.js
@@ -576,7 +576,7 @@ function getServerStatus(port) {
   return function() {
     return new Promise(function(fulfil, reject) {
       var spawn = require('child_process').spawn;
-      var child = spawn('lsof', ['-t', '-i',  'TCP:' + port]);
+      var child = spawn('fuser', [port + '/tcp']);
       var count = 0;
 
       child.stdout.on('data', function(chunk) {


### PR DESCRIPTION
The following 2 changes are done because of the following reasons:
1. transport tag is changed in infinispan-clustered.xml, because with newest built server the cluster was not formed, i.e. 3 servers which were running with this config didn't see each other and didn't form cluster. With this change it works as expected.

2. lsof command is replaced with fuser one, as on jenkins which the tests are running lsof command was missing.