### PR TITLE
lib: add callback to write() to catch error

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -259,10 +259,19 @@
         });
       },
       write: function(buffer) {
-        var flushed = sock.write(buffer);
-        if (!flushed)
-          logger.debugf('Buffer write not fully flushed, part of of data queued for: %s',
-            buffer.toString('hex').toUpperCase());
+        return new Promise(function (fulfill, reject) {
+          var flushed = sock.write(buffer, (err) => {
+            if (err) {
+              logger.error('Error writing to socket: %s', err);
+              transport.retryRpcs(addr); // retry RPCs in case of error
+            }
+            fulfill();
+          });
+          if (!flushed)
+            logger.debugf('Buffer write not fully flushed, part of of data queued for: %s',
+              buffer.toString('hex').toUpperCase());
+        });
+
       },
       getAddress: function() {
         return addr;


### PR DESCRIPTION
Since Node.js 15.0.0, the socket end error will only be emitted if a
callback is passed to the socket.write() method.

This commit should allow tests to pass in Node.js 16.

----

This is a draft fix - please run through CI, as I am unsure if there are any unwarranted side-effects.