### PR TITLE
deps: replace outdated bitwise-xor with buffer-xor

### DIFF
--- a/lib/sasl/bitops.js
+++ b/lib/sasl/bitops.js
@@ -1,7 +1,6 @@
 var createHash = require('create-hash');
 var createHmac = require('create-hmac');
-var xor = require('bitwise-xor');
-
+var xor = require('buffer-xor');
 
 exports.XOR = xor;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,11 +79,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bitwise-xor": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/bitwise-xor/-/bitwise-xor-0.0.0.tgz",
-      "integrity": "sha1-BAqBcrW7jMVisLcRnyMLKhp4Dj0="
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -98,6 +93,14 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer-xor": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz",
+      "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
       }
     },
     "call-bind": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/infinispan/js-client"
   },
   "dependencies": {
-    "bitwise-xor": "0.0.0",
+    "buffer-xor": "^2.0.2",
     "create-hash": "^1.1.0",
     "create-hmac": "^1.1.3",
     "log4js": "^3.0.5",


### PR DESCRIPTION
The `bitwise-xor` package has not been updated in 8 years and uses the
deprecated `new Buffer` constructor. Replace it with the `buffer-xor`
package. This package is more widely used in the ecosystem and should be
a drop-in replacement.

----

Comparing [`bitwise-xor`](https://www.npmjs.com/package/bitwise-xor) to [`buffer-xor`](https://www.npmjs.com/package/buffer-xor):
  * No publish of  `bitwise-xor` for 8 years and still at v0.0.0 on npm.
  * `bitwise-xor` has ~14,000 downloads versus `buffer-xor` with ~11,500,000 (so more ecosystem scrutiny on `buffer-xor`).
  * `bitwise-xor` uses the [deprecated `new Buffer()` constructor](https://github.com/czzarr/node-bitwise-xor/blob/master/index.js).
  
----

I have a few dependency update PRs - but figured it makes sense to open them as separate PRs so we can isolate any potential problems or test failures.