### PR TITLE
JDG-5557 - Fixing queryCache example

### DIFF
--- a/documentation/asciidoc/topics/code_examples/queries.js
+++ b/documentation/asciidoc/topics/code_examples/queries.js
@@ -1,9 +1,9 @@
-var infinispan = require('infinispan');
-var protobuf = require('protobufjs');
+const infinispan = require('infinispan');
+const protobuf = require('protobufjs');
 // This example uses async/await paradigma
 (async function () {
-// User data protobuf definition
-  var cacheValueProtoDef = `package awesomepackage;
+  // User data protobuf definition
+  const cacheValueProtoDef = `package awesomepackage;
   /**
    * @TypeId(1000044)
    */
@@ -12,54 +12,54 @@ var protobuf = require('protobufjs');
       required int64 age = 2;
       required bool isVerified =3;
   }`
-  var protoMetaClient;
-  var client;
+  let protoMetaClient;
+  let client;
   try {
     // Creating clients for two caches:
     // - ___protobuf_metadata for registering .proto file
     // - queryCache for user data
-    var connectProp = { port: 11222, host: '127.0.0.1' };
-    var commonOpts = {
+    const connectProp = { port: 11222, host: '127.0.0.1' };
+    const commonOpts = {
       version: '3.0',
       authentication: {
         enabled: true,
-        saslMechanism: 'PLAIN',
+        saslMechanism: 'DIGEST-MD5',
         userName: 'admin',
         password: 'pass'
       }
     };
-    var protoMetaClientOps = {
+    const protoMetaClientOps = {
       cacheName: '___protobuf_metadata',
       dataFormat: { keyType: "text/plain", valueType: "text/plain" }
     }
-    var clientOps = {
+    const clientOps = {
       dataFormat: { keyType: "text/plain", valueType: "application/x-protostream" },
       cacheName: 'queryCache'
     }
-    protoMetaClient = await infinispan.client(connectProp, Object.assign(commonOpts,protoMetaClientOps));
-    client = await infinispan.client(connectProp, Object.assign(commonOpts,clientOps));
+    protoMetaClient = await infinispan.client(connectProp, Object.assign(commonOpts, protoMetaClientOps));
+    client = await infinispan.client(connectProp, Object.assign(commonOpts, clientOps));
 
     // Registering protobuf definition on server
     await protoMetaClient.put("awesomepackage/AwesomeUser.proto", cacheValueProtoDef);
 
     // Registering protobuf definition on protobufjs
-    var root = protobuf.parse(cacheValueProtoDef).root;
-    var AwesomeUser = root.lookupType(".awesomepackage.AwesomeUser");
+    const root = protobuf.parse(cacheValueProtoDef).root;
+    const AwesomeUser = root.lookupType(".awesomepackage.AwesomeUser");
     client.registerProtostreamRoot(root);
     client.registerProtostreamType(".awesomepackage.AwesomeUser", 1000044);
-    
+
     // Cleanup and populating the cache
     await client.clear();
     for (let i = 0; i < 10; i++) {
-      var payload = { name: "AwesomeName" + i, age: i, isVerified: (Math.random() < 0.5) };
-      var message = AwesomeUser.create(payload);
+      const payload = { name: "AwesomeName" + i, age: i, isVerified: (Math.random() < 0.5) };
+      const message = AwesomeUser.create(payload);
       console.log("Creating entry:", message);
       await client.put(i.toString(), message)
     }
     // Run the query
-    var queryStr = `select u.name,u.age from awesomepackage.AwesomeUser u where u.age<20 order by u.name asc`;
+    const queryStr = `select u.name,u.age from awesomepackage.AwesomeUser u where u.age<20 order by u.name asc`;
     console.log("Running query:", queryStr);
-    var query = await client.query({ queryString: queryStr });
+    const query = await client.query({ queryString: queryStr });
     console.log("Query result:");
     console.log(query);
   } catch (err) {

--- a/documentation/asciidoc/topics/code_examples/queries.js
+++ b/documentation/asciidoc/topics/code_examples/queries.js
@@ -12,8 +12,6 @@ const protobuf = require('protobufjs');
       required int64 age = 2;
       required bool isVerified =3;
   }`
-  let protoMetaClient;
-  let client;
   try {
     // Creating clients for two caches:
     // - ___protobuf_metadata for registering .proto file
@@ -36,8 +34,8 @@ const protobuf = require('protobufjs');
       dataFormat: { keyType: "text/plain", valueType: "application/x-protostream" },
       cacheName: 'queryCache'
     }
-    protoMetaClient = await infinispan.client(connectProp, Object.assign(commonOpts, protoMetaClientOps));
-    client = await infinispan.client(connectProp, Object.assign(commonOpts, clientOps));
+    var protoMetaClient = await infinispan.client(connectProp, Object.assign(commonOpts, protoMetaClientOps));
+    var client = await infinispan.client(connectProp, Object.assign(commonOpts, clientOps));
 
     // Registering protobuf definition on server
     await protoMetaClient.put("awesomepackage/AwesomeUser.proto", cacheValueProtoDef);
@@ -75,7 +73,7 @@ const protobuf = require('protobufjs');
 })();
 
 function handleError(err) {
-  if (err.includes("'queryCache' not found")) {
+  if (err.message.includes("'queryCache' not found")) {
     console.log('*** ERROR ***');
     console.log(`*** This example needs a cache 'queryCache' with the following config:
     {


### PR DESCRIPTION
ECMAScript 6 introduced the "let" statement, which should become the final specification. 

Also, the PLAIN auth mechanism is not supported any more by Infinispan, is it?

https://issues.redhat.com/browse/JDG-5557