### PR TITLE
Remove spurious param from hello-world example.

### DIFF
--- a/documentation/asciidoc/topics/code_examples/connection-xsite-cluster-switch.js
+++ b/documentation/asciidoc/topics/code_examples/connection-xsite-cluster-switch.js
@@ -19,17 +19,17 @@ connected.then(function (client) {
   switchToB.then(function(switchSucceed) {
 
     if (switchSucceed) {
-      ...
+      // ...
     }
 
-    ...
+    // ...
 
     var switchToDefault = client.getTopologyInfo().switchToDefaultCluster();
 
     switchToDefault.then(function(switchSucceed) {
 
       if (switchSucceed) {
-        ...
+        // ...
       }
 
     })

--- a/documentation/asciidoc/topics/code_examples/encryption-private-key.js
+++ b/documentation/asciidoc/topics/code_examples/encryption-private-key.js
@@ -6,7 +6,7 @@ var connected = infinispan.client({port: 11222, host: '127.0.0.1'},
       clientAuth: {
         key: 'privkey.pem',
         passphrase: 'secret',
-        cert:ssl 'cert.pem'
+        cert: 'cert.pem'
       }
     }
   }

--- a/documentation/asciidoc/topics/code_examples/hello-world.js
+++ b/documentation/asciidoc/topics/code_examples/hello-world.js
@@ -6,7 +6,7 @@ var connected = infinispan.client(
   {port: 11222, host: '127.0.0.1'},
   {
     cacheName: 'myCache',
-    clientIntelligence: 'BASIC',
+    topologyUpdates: false,
     authentication: {
       enabled: true,
       saslMechanism: 'DIGEST-MD5',

--- a/documentation/asciidoc/topics/code_examples/register-event-listener.js
+++ b/documentation/asciidoc/topics/code_examples/register-event-listener.js
@@ -1,7 +1,7 @@
 var infinispan = require('infinispan');
 
 var connected = infinispan.client(
-  {port: 11222, host: '127.0.0.1'}
+  {port: 11222, host: '127.0.0.1'},
   {
     // Configure client connections with authentication and encryption here.
   }


### PR DESCRIPTION
hello-world.js referred to `clientIntelligence` which is actually `topologyUpdates` in the JS client.

Also some of the other examples had parse error which this PR fixes.
