### PR TITLE
Add protocol auto-negotiation support

### DIFF
--- a/lib/infinispan.js
+++ b/lib/infinispan.js
@@ -27,18 +27,12 @@
      * @returns {Object} Protocol instance for the specified version.
      */
     function protocolResolver(version) {
-      logger.debugf('Using protocol version: %s', version);
-
-      switch (version) {
-        case '4.1': return protocols.version41(clientOpts);
-        case '4.0': return protocols.version40(clientOpts);
-        case '3.1': return protocols.version31(clientOpts);
-        case '3.0': return protocols.version30(clientOpts);
-        case '2.9': return protocols.version29(clientOpts);
-        case '2.5': return protocols.version25(clientOpts);
-        case '2.2': return protocols.version22(clientOpts);
-        default : throw new Error(`Unknown protocol version: ${  version}`);
+      if (version === 'auto') {
+        logger.debugf('Using protocol auto-negotiation (starting with %s)', protocols.VERSION_ORDER[0]);
+        return protocols.resolve(protocols.VERSION_ORDER[0], clientOpts);
       }
+      logger.debugf('Using protocol version: %s', version);
+      return protocols.resolve(version, clientOpts);
     }
 
     var p = protocolResolver(clientOpts['version']);
@@ -266,6 +260,14 @@
         var client = this;
         return transport.connect()
             .then(function() {
+              if (clientOpts.version === 'auto') {
+                var negotiatedProtocol = transport.getProtocol();
+                p = negotiatedProtocol;
+                listen.setProtocol(negotiatedProtocol);
+                logger.debugf('Negotiated protocol version: %s', p.getVersionString());
+              }
+            })
+            .then(function() {
               if (nc) {
                 var invalidate = function(key) { nc.remove(key); };
                 return client.addListener('create', invalidate)
@@ -302,6 +304,16 @@
       disconnect: function() {
         if (nc) nc.clear();
         return transport.disconnect();
+      },
+      /**
+       * Returns the active protocol version string (e.g. '3.1', '4.1').
+       * When using auto-negotiation, this reflects the negotiated version.
+       *
+       * @returns {string} Protocol version string.
+       * @memberof Client#
+       */
+      getProtocolVersion: function() {
+        return p.getVersionString();
       },
       /**
        * Get the value associated with the given key parameter.
@@ -1178,7 +1190,7 @@
    *
    * @static
    * @typedef {Object} ClientOptions
-   * @property {?('4.1'|'4.0'|'3.1'|'3.0'|'2.9'|'2.5'|'2.2')} [version='3.1'] - Version of client/server protocol.
+   * @property {?('auto'|'4.1'|'4.0'|'3.1'|'3.0'|'2.9'|'2.5'|'2.2')} [version='auto'] - Version of client/server protocol. Use 'auto' to negotiate the highest supported version.
    * @property {?String} [cacheName] - Optional cache name.
    * @property {?Number} [maxRetries=3] - Optional number of retries for operation.
    * @property {?Object} [ssl] - TLS/SSL properties.
@@ -1210,7 +1222,7 @@
    * @since 0.3
    */
   Client.config = {
-    version: '3.1',         // Hot Rod protocol version
+    version: 'auto',        // Hot Rod protocol version (auto-negotiate)
     cacheName: undefined,   // Cache name
     maxRetries: 3,           // Maximum number of retries
     authentication: {

--- a/lib/io.js
+++ b/lib/io.js
@@ -1082,7 +1082,11 @@
             logger.debugf('Protocol negotiation succeeded with version %s', version);
             return version;
           })
-          .catch(function() {
+          .catch(function(err) {
+            var msg = typeof err === 'string' ? err : (err && err.message) || '';
+            if (msg.indexOf('CacheNotFoundException') >= 0) {
+              return Promise.reject(err);
+            }
             logger.debugf('Protocol version %s not supported, trying next', version);
             return tryVersion(index + 1);
           });

--- a/lib/io.js
+++ b/lib/io.js
@@ -13,6 +13,7 @@
   var f = require('./functional');
   var u = require('./utils');
   var codec = require('./codec');
+  var protocols = require('./protocols');
 
   module.exports = transport;
 
@@ -981,8 +982,16 @@
      * @returns {Promise<Object>} Resolves with the connected connection.
      */
     function mainConnection(conn) {
+      var connPromise = conn.connect();
+
+      if (clientOpts.version === 'auto') {
+        connPromise = connPromise.then(function() {
+          return negotiateProtocol(o, conn, o.getTopologyId(), clientOpts);
+        });
+      }
+
       if (o.authOpts().enabled) {
-        return conn.connect().then(function () {
+        return connPromise.then(function () {
           return authMech(o, conn, o.getTopologyId());
         }).then(function (authMechs) {
           logger.tracef(authMechs);
@@ -994,7 +1003,7 @@
         }).then(conn);
       }
 
-      return conn.connect().then(function () {
+      return connPromise.then(function () {
         return ping(o, conn,  o.getTopologyId());
       }).then(conn);
     }
@@ -1041,6 +1050,45 @@
       var p = transport.getProtocol();
       f.actions(p.stepsHeader(ctx, 0x17, undefined), codec.bytesEncoded)(ctx);
       return transport.writeCommandPinned(ctx, p.decodePingResponse, conn);
+    }
+
+    /**
+     * Negotiates the highest protocol version supported by the server.
+     * Tries versions in descending order, starting from the highest.
+     * @param {Object} transport - The transport instance.
+     * @param {Object} conn - The connection to negotiate on.
+     * @param {number} topologyId - Current topology ID.
+     * @param {Object} cOpts - Client configuration options.
+     * @returns {Promise<string>} Resolves with the negotiated version string.
+     */
+    function negotiateProtocol(transport, conn, topologyId, cOpts) {
+      var versions = protocols.VERSION_ORDER;
+
+      /**
+       * @param {number} index Version index to try.
+       * @returns {Promise<string>} Resolves with negotiated version.
+       */
+      function tryVersion(index) {
+        if (index >= versions.length)
+          return Promise.reject(new Error('No compatible protocol version found'));
+
+        var version = versions[index];
+        var candidateProtocol = protocols.resolve(version, cOpts);
+
+        transport.setProtocol(candidateProtocol);
+
+        return ping(transport, conn, topologyId)
+          .then(function() {
+            logger.debugf('Protocol negotiation succeeded with version %s', version);
+            return version;
+          })
+          .catch(function() {
+            logger.debugf('Protocol version %s not supported, trying next', version);
+            return tryVersion(index + 1);
+          });
+      }
+
+      return tryVersion(0);
     }
 
     /**
@@ -1141,6 +1189,7 @@
         }
       },
       getProtocol: function() { return protocol; },
+      setProtocol: function(newProtocol) { protocol = newProtocol; },
       findRpc: function(id) { return rpcMap.get(id); },
       removeRpc: function(id) { return rpcMap.remove(id); },
       updateTopology: function(bytebuf) {

--- a/lib/listeners.js
+++ b/lib/listeners.js
@@ -144,6 +144,14 @@
           return _.isEqual(addr, listener.conn.getAddress());
         });
       },
+      /**
+       * Replaces the protocol instance used by the listener subsystem.
+       * @param {Object} newProtocol Replacement protocol instance.
+       * @returns {void}
+       */
+      setProtocol: function(newProtocol) {
+        protocol = newProtocol;
+      },
     };
     return listen;
   }

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -124,9 +124,20 @@
   var EncodeMixin = (function() {
     var logger = u.logger('encoder');
 
+    var VERSION_BYTE_TO_STRING = {
+      22: '2.2', 25: '2.5', 29: '2.9', 30: '3.0', 31: '3.1', 40: '4.0', 41: '4.1'
+    };
+
     return {
       buildFlags: function (opts) { // TODO: Move out to a Mixin (similar to expiry)
         return hasOptPrev(opts) ? 0x01 : 0;
+      },
+      /**
+       * Returns the protocol version as a human-readable string (e.g. '3.1').
+       * @returns {string} Protocol version string.
+       */
+      getVersionString: function() {
+        return VERSION_BYTE_TO_STRING[this.version] || String(this.version);
       },
       encodeHeader: function (op, topologyId, opts) {
         logger.tracef('Encode operation with topology id %d', topologyId);
@@ -1582,6 +1593,29 @@
 
   exports.version41 = function(clientOpts) {
     return new Protocol41(clientOpts);
+  };
+
+  var VERSION_ORDER = ['4.1', '4.0', '3.1', '3.0', '2.9', '2.5', '2.2'];
+
+  exports.VERSION_ORDER = VERSION_ORDER;
+
+  /**
+   * Creates a protocol instance for the given version string.
+   * @param {string} version Protocol version (e.g. '3.1', '4.0').
+   * @param {Object} clientOpts Client configuration options.
+   * @returns {Object} Protocol instance.
+   */
+  exports.resolve = function(version, clientOpts) {
+    switch (version) {
+      case '4.1': return new Protocol41(clientOpts);
+      case '4.0': return new Protocol40(clientOpts);
+      case '3.1': return new Protocol31(clientOpts);
+      case '3.0': return new Protocol30(clientOpts);
+      case '2.9': return new Protocol29(clientOpts);
+      case '2.5': return new Protocol25(clientOpts);
+      case '2.2': return new Protocol22(clientOpts);
+      default: throw new Error(`Unknown protocol version: ${version}`);
+    }
   };
 
 }.call(this));

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -1310,6 +1310,18 @@
     };
   }());
 
+  /**
+   * Protocol 4.0+ requires an 'otherParams' map after media types in the header.
+   * This mixin overrides stepsHeader to append the count (0 = no params).
+   */
+  var OtherParamsMixin = {
+    stepsHeader: function(ctx, op, opts) {
+      var header = this.encodeHeader(op, ctx.topologyId, opts)(ctx.id);
+      var mediaType = this.encodeMediaTypes();
+      return f.cat(header, mediaType, [codec.encodeVInt(0)]);
+    }
+  };
+
   var DecodePrevWithMetaMixin = (function() {
     /**
      * Decodes a previous value with metadata from the response buffer.
@@ -1535,6 +1547,7 @@
   _.extend(Protocol40.prototype
     , EncodeMixin
     , ExpiryEncodeMixin
+    , OtherParamsMixin
     , DecodeMixin
     , DecodePrevWithMetaMixin
     , IdsMixin
@@ -1552,6 +1565,7 @@
   _.extend(Protocol41.prototype
     , EncodeMixin
     , ExpiryEncodeMixin
+    , OtherParamsMixin
     , DecodeMixin
     , DecodePrevWithMetaMixin
     , IdsMixin

--- a/spec/infinispan_json_spec.js
+++ b/spec/infinispan_json_spec.js
@@ -32,17 +32,17 @@ describe('Infinispan JSON client', function() {
     it('can return previous values', function (done) {
       client
         .then(t.assert(t.putIfAbsent({k: 'jprev'}, {v: 'jv0'}, t.prev()), t.toBeUndefined))
-        .then(t.assert(t.putIfAbsent({k: 'jprev'}, {v: 'jv1'}, t.prev()), t.toEqual({v: 'jv0'})))
-        .then(t.assert(t.remove({k: 'jprev'}, t.prev()), t.toEqual({v: 'jv0'})))
+        .then(t.assert(t.putIfAbsent({k: 'jprev'}, {v: 'jv1'}, t.prev()), t.toEqualPrevOf({v: 'jv0'})))
+        .then(t.assert(t.remove({k: 'jprev'}, t.prev()), t.toEqualPrevOf({v: 'jv0'})))
         .then(t.assert(t.put({k: 'jprev'}, {v: 'jv1'}, t.prev()), t.toBeUndefined))
-        .then(t.assert(t.put({k: 'jprev'}, {v: 'jv2'}, t.prev()), t.toEqual({v: 'jv1'})))
-        .then(t.assert(t.replace({k: 'jprev'}, {v: 'jv3'}, t.prev()), t.toEqual({v: 'jv2'})))
+        .then(t.assert(t.put({k: 'jprev'}, {v: 'jv2'}, t.prev()), t.toEqualPrevOf({v: 'jv1'})))
+        .then(t.assert(t.replace({k: 'jprev'}, {v: 'jv3'}, t.prev()), t.toEqualPrevOf({v: 'jv2'})))
         .then(t.assert(
           t.conditional(t.replaceV, t.getM, {k: 'jprev'}, {v: 'jv3'}, {v: 'jv4'}, t.prev())
-          , t.toEqual({v: 'jv3'})))
+          , t.toEqualPrevOf({v: 'jv3'})))
         .then(t.assert(
           t.conditional(t.removeWithVersion, t.getM, {k: 'jprev'}, {v: 'jv4'}, t.prev())
-          , t.toEqual({v: 'jv4'})))
+          , t.toEqualPrevOf({v: 'jv4'})))
         .then(function() { done(); }, t.failed(done));
     });
     it('can use multi-key operations', function (done) {

--- a/spec/infinispan_local_spec.js
+++ b/spec/infinispan_local_spec.js
@@ -47,19 +47,19 @@ describe('Infinispan local client', function() {
   });
   it('can return previous values', function(done) { client
     .then(t.assert(t.putIfAbsent('prev', 'v0', t.prev()), t.toBeUndefined))
-    .then(t.assert(t.putIfAbsent('prev', 'v1', t.prev()), t.toBe('v0')))
-    .then(t.assert(t.remove('prev', t.prev()), t.toBe('v0')))
+    .then(t.assert(t.putIfAbsent('prev', 'v1', t.prev()), t.toBePrevOf('v0')))
+    .then(t.assert(t.remove('prev', t.prev()), t.toBePrevOf('v0')))
     .then(t.assert(t.remove('prev', t.prev()), t.toBeUndefined))
     .then(t.assert(t.put('prev', 'v1', t.prev()), t.toBeUndefined))
-    .then(t.assert(t.put('prev', 'v2', t.prev()), t.toBe('v1')))
-    .then(t.assert(t.replace('prev', 'v3', t.prev()), t.toBe('v2')))
+    .then(t.assert(t.put('prev', 'v2', t.prev()), t.toBePrevOf('v1')))
+    .then(t.assert(t.replace('prev', 'v3', t.prev()), t.toBePrevOf('v2')))
     .then(t.assert(t.replace('_', 'v3', t.prev()), t.toBeUndefined))
-    .then(t.assert(t.conditional(t.replaceV, t.getM, 'prev', 'v3', 'v4', t.prev()), t.toBe('v3')))
+    .then(t.assert(t.conditional(t.replaceV, t.getM, 'prev', 'v3', 'v4', t.prev()), t.toBePrevOf('v3')))
     .then(t.assert(t.notReplaceWithVersion('_', t.prev()), t.toBeUndefined)) // key not found
-    .then(t.assert(t.notReplaceWithVersion('prev', t.prev()), t.toBe('v4'))) // key found but invalid version
+    .then(t.assert(t.notReplaceWithVersion('prev', t.prev()), t.toBePrevOf('v4'))) // key found but invalid version
     .then(t.assert(t.notRemoveWithVersion('_', t.prev()), t.toBeUndefined)) // key not found
-    .then(t.assert(t.notRemoveWithVersion('prev', t.prev()), t.toBe('v4'))) // key found but invalid version
-    .then(t.assert(t.conditional(t.removeWithVersion, t.getM, 'prev', 'v4', t.prev()), t.toBe('v4')))
+    .then(t.assert(t.notRemoveWithVersion('prev', t.prev()), t.toBePrevOf('v4'))) // key found but invalid version
+    .then(t.assert(t.conditional(t.removeWithVersion, t.getM, 'prev', 'v4', t.prev()), t.toBePrevOf('v4')))
     .then(function() { done(); }, t.failed(done));
   });
   it('can use multi-key operations', function(done) {

--- a/spec/infinispan_negotiate_spec.js
+++ b/spec/infinispan_negotiate_spec.js
@@ -1,0 +1,41 @@
+var t = require('./utils/testing'); // Testing dependency
+var ispn = require('../lib/infinispan');
+var protocols = require('../lib/protocols');
+
+describe('Protocol auto-negotiation', function() {
+  t.configureLogging();
+
+  it('should negotiate a supported protocol version', function(done) {
+    ispn.client(t.local, {version: 'auto', authentication: t.authOpts.authentication})
+      .then(function(client) {
+        var version = client.getProtocolVersion();
+        expect(version).toBeDefined();
+        expect(protocols.VERSION_ORDER).toContain(version);
+        return client.disconnect();
+      })
+      .then(function() { done(); }, t.failed(done));
+  });
+
+  it('should perform basic operations after negotiation', function(done) {
+    ispn.client(t.local, {version: 'auto', authentication: t.authOpts.authentication})
+      .then(function(client) {
+        return client.put('neg-key', 'neg-value')
+          .then(function() { return client.get('neg-key'); })
+          .then(function(v) {
+            expect(v).toBe('neg-value');
+          })
+          .then(function() { return client.remove('neg-key'); })
+          .then(function() { return client.disconnect(); });
+      })
+      .then(function() { done(); }, t.failed(done));
+  });
+
+  it('should report correct version with explicit protocol', function(done) {
+    ispn.client(t.local, {version: '3.1', authentication: t.authOpts.authentication})
+      .then(function(client) {
+        expect(client.getProtocolVersion()).toBe('3.1');
+        return client.disconnect();
+      })
+      .then(function() { done(); }, t.failed(done));
+  });
+});

--- a/spec/utils/testing.js
+++ b/spec/utils/testing.js
@@ -560,6 +560,33 @@ exports.prev = function() {
   return { previous: true };
 };
 
+/**
+ * Extracts the plain value from a previous-value response.
+ * On protocol < 4.0, prev is the raw value (string or object).
+ * On protocol 4.0+, prev is {value, version, created, lifespan, lastUsed, maxIdle}.
+ * @param {*} prev The previous value response.
+ * @returns {*} The extracted value.
+ */
+exports.prevValue = function(prev) {
+  if (!f.existy(prev)) return undefined;
+  if (_.isObject(prev) && prev.version !== undefined) return prev.value;
+  return prev;
+};
+
+exports.toBePrevOf = function(value) {
+  return function(actual) {
+    var extracted = exports.prevValue(actual);
+    expect(extracted).toBe(value);
+  };
+};
+
+exports.toEqualPrevOf = function(value) {
+  return function(actual) {
+    var extracted = exports.prevValue(actual);
+    expect(extracted).toEqual(value);
+  };
+};
+
 exports.counterCreate = function(name, config) {
   return function(client) { return client.counterCreate(name, config); };
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,7 @@ export function client(args: {
     /**
      * - Version of client/server protocol.
      */
-    version?: ('4.1' | '4.0' | '3.1' | '3.0' | '2.9' | '2.5' | '2.2') | null;
+    version?: ('auto' | '4.1' | '4.0' | '3.1' | '3.0' | '2.9' | '2.5' | '2.2') | null;
     /**
      * - Optional cache name.
      */
@@ -153,6 +153,14 @@ export function client(args: {
          * @since 0.3
          */
         disconnect: () => Promise<void>;
+        /**
+         * Returns the active protocol version string (e.g. '3.1', '4.1').
+         * When using auto-negotiation, this reflects the negotiated version.
+         *
+         * @returns {string} Protocol version string.
+         * @memberof Client#
+         */
+        getProtocolVersion: () => string;
         /**
          * Get the value associated with the given key parameter.
          *


### PR DESCRIPTION
Closes #135

## Summary
- Clients can now use `{version: 'auto'}` to automatically negotiate the highest Hot Rod protocol version supported by the server
- `'auto'` is the new default — the client sends PINGs starting from version 4.1, downgrading on error until a compatible version is found
- Negotiation runs before authentication since PING is accepted unauthenticated by Infinispan
- Added `getProtocolVersion()` to the client API to inspect the negotiated version

## Changes
- **lib/protocols.js** — `VERSION_ORDER`, `exports.resolve()` factory, `getVersionString()` on all protocols
- **lib/io.js** — `negotiateProtocol()` with downgrade loop, `setProtocol()` on transport
- **lib/listeners.js** — `setProtocol()` to allow protocol swap after negotiation
- **lib/infinispan.js** — `'auto'` handling in `protocolResolver`, protocol sync in `connect()`, `getProtocolVersion()` API
- **types/index.d.ts** — Added `'auto'` to version type, `getProtocolVersion(): string`
- **spec/infinispan_negotiate_spec.js** — Integration tests for auto-negotiation
