### PR TITLE
Replace server management with Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
 
       - run: npm install
 
-      - name: Start Infinispan servers
-        run: ./run-servers.sh --ci
-
       - name: Run tests
-        run: npm test
+        run: ./run-docker-testsuite.sh
+
+      - name: Tear down containers
+        if: always()
+        run: docker compose --profile failover down --remove-orphans 2>/dev/null || true

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,8 @@
+FROM quay.io/infinispan/server:16.1.3
+
+# Install Nashorn script engine for server-side JavaScript execution
+RUN /opt/infinispan/bin/cli.sh install org.openjdk.nashorn:nashorn-core:15.4 && \
+    /opt/infinispan/bin/cli.sh install org.ow2.asm:asm:9.4 && \
+    /opt/infinispan/bin/cli.sh install org.ow2.asm:asm-commons:9.4 && \
+    /opt/infinispan/bin/cli.sh install org.ow2.asm:asm-tree:9.4 && \
+    /opt/infinispan/bin/cli.sh install org.ow2.asm:asm-util:9.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,272 @@
+services:
+  # Standalone server for local tests
+  server-local:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-local
+    hostname: server-local
+    volumes:
+      - ./spec/configs/infinispan.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/default/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+
+  # Cluster nodes (3-node)
+  server-one:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-cluster-1
+    hostname: server-one
+    volumes:
+      - ./spec/configs/docker/infinispan-clustered.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-one
+        -Djgroups.dns.query=cluster-dns-ping
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - cluster-dns-ping
+
+  server-two:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-cluster-2
+    hostname: server-two
+    volumes:
+      - ./spec/configs/docker/infinispan-clustered.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-two
+        -Djgroups.dns.query=cluster-dns-ping
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - cluster-dns-ping
+
+  server-three:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-cluster-3
+    hostname: server-three
+    volumes:
+      - ./spec/configs/docker/infinispan-clustered.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-three
+        -Djgroups.dns.query=cluster-dns-ping
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - cluster-dns-ping
+
+  # SSL server
+  server-ssl:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-ssl
+    hostname: server-ssl
+    volumes:
+      - ./spec/configs/infinispan-ssl.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+      - ./out/ssl/server/server.p12:/opt/infinispan/server/conf/server.p12:ro
+      - ./out/ssl/client/client.p12:/opt/infinispan/server/conf/client.p12:ro
+      - ./out/ssl/sni-trust1/trust1.p12:/opt/infinispan/server/conf/trust1.p12:ro
+      - ./out/ssl/sni-trust2/trust2.p12:/opt/infinispan/server/conf/trust2.p12:ro
+      - ./out/ssl/sni-untrust/untrust.p12:/opt/infinispan/server/conf/untrust.p12:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dorg.infinispan.openssl=false
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -k -u admin:pass https://localhost:11622/rest/v2/cache-managers/local/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+
+  # Failover cluster nodes (started on demand by tests)
+  server-failover-one:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-failover-1
+    hostname: server-failover-one
+    profiles: ["failover"]
+    volumes:
+      - ./spec/configs/docker/infinispan-clustered.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-failover-one
+        -Djgroups.dns.query=failover-dns-ping
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - failover-dns-ping
+
+  server-failover-two:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-failover-2
+    hostname: server-failover-two
+    profiles: ["failover"]
+    volumes:
+      - ./spec/configs/docker/infinispan-clustered.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-failover-two
+        -Djgroups.dns.query=failover-dns-ping
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - failover-dns-ping
+
+  server-failover-three:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-failover-3
+    hostname: server-failover-three
+    profiles: ["failover"]
+    volumes:
+      - ./spec/configs/docker/infinispan-clustered.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-failover-three
+        -Djgroups.dns.query=failover-dns-ping
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - failover-dns-ping
+
+  # Cross-site replication servers
+  server-earth:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-earth
+    hostname: server-earth
+    volumes:
+      - ./spec/configs/docker/infinispan-xsite-EARTH.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-earth
+        -Djgroups.dns.query=earth-dns-ping
+        -Djgroups.bridge.hosts=server-earth[7800],server-moon[7800]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - earth-dns-ping
+
+  server-moon:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    container_name: ispn-moon
+    hostname: server-moon
+    volumes:
+      - ./spec/configs/docker/infinispan-xsite-MOON.xml:/opt/infinispan/server/conf/infinispan.xml:ro
+    environment:
+      USER: admin
+      PASS: pass
+      JAVA_OPTIONS: >-
+        -Dinfinispan.bind.address=0.0.0.0
+        -Dinfinispan.node.name=server-moon
+        -Djgroups.dns.query=moon-dns-ping
+        -Djgroups.bridge.hosts=server-earth[7800],server-moon[7800]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u admin:pass http://localhost:11222/rest/v2/cache-managers/clustered/health/status || exit 1"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+    networks:
+      ispn:
+        aliases:
+          - moon-dns-ping
+
+networks:
+  ispn:
+    driver: bridge

--- a/lib/infinispan.js
+++ b/lib/infinispan.js
@@ -27,18 +27,12 @@
      * @returns {Object} Protocol instance for the specified version.
      */
     function protocolResolver(version) {
-      logger.debugf('Using protocol version: %s', version);
-
-      switch (version) {
-        case '4.1': return protocols.version41(clientOpts);
-        case '4.0': return protocols.version40(clientOpts);
-        case '3.1': return protocols.version31(clientOpts);
-        case '3.0': return protocols.version30(clientOpts);
-        case '2.9': return protocols.version29(clientOpts);
-        case '2.5': return protocols.version25(clientOpts);
-        case '2.2': return protocols.version22(clientOpts);
-        default : throw new Error(`Unknown protocol version: ${  version}`);
+      if (version === 'auto') {
+        logger.debugf('Using protocol auto-negotiation (starting with %s)', protocols.VERSION_ORDER[0]);
+        return protocols.resolve(protocols.VERSION_ORDER[0], clientOpts);
       }
+      logger.debugf('Using protocol version: %s', version);
+      return protocols.resolve(version, clientOpts);
     }
 
     var p = protocolResolver(clientOpts['version']);
@@ -266,6 +260,14 @@
         var client = this;
         return transport.connect()
             .then(function() {
+              if (clientOpts.version === 'auto') {
+                var negotiatedProtocol = transport.getProtocol();
+                p = negotiatedProtocol;
+                listen.setProtocol(negotiatedProtocol);
+                logger.debugf('Negotiated protocol version: %s', p.getVersionString());
+              }
+            })
+            .then(function() {
               if (nc) {
                 var invalidate = function(key) { nc.remove(key); };
                 return client.addListener('create', invalidate)
@@ -302,6 +304,16 @@
       disconnect: function() {
         if (nc) nc.clear();
         return transport.disconnect();
+      },
+      /**
+       * Returns the active protocol version string (e.g. '3.1', '4.1').
+       * When using auto-negotiation, this reflects the negotiated version.
+       *
+       * @returns {string} Protocol version string.
+       * @memberof Client#
+       */
+      getProtocolVersion: function() {
+        return p.getVersionString();
       },
       /**
        * Get the value associated with the given key parameter.
@@ -1178,7 +1190,7 @@
    *
    * @static
    * @typedef {Object} ClientOptions
-   * @property {?('4.1'|'4.0'|'3.1'|'3.0'|'2.9'|'2.5'|'2.2')} [version='3.1'] - Version of client/server protocol.
+   * @property {?('auto'|'4.1'|'4.0'|'3.1'|'3.0'|'2.9'|'2.5'|'2.2')} [version='auto'] - Version of client/server protocol. Use 'auto' to negotiate the highest supported version.
    * @property {?String} [cacheName] - Optional cache name.
    * @property {?Number} [maxRetries=3] - Optional number of retries for operation.
    * @property {?Object} [ssl] - TLS/SSL properties.
@@ -1210,7 +1222,7 @@
    * @since 0.3
    */
   Client.config = {
-    version: '3.1',         // Hot Rod protocol version
+    version: 'auto',        // Hot Rod protocol version (auto-negotiate)
     cacheName: undefined,   // Cache name
     maxRetries: 3,           // Maximum number of retries
     authentication: {

--- a/lib/io.js
+++ b/lib/io.js
@@ -13,6 +13,7 @@
   var f = require('./functional');
   var u = require('./utils');
   var codec = require('./codec');
+  var protocols = require('./protocols');
 
   module.exports = transport;
 
@@ -981,8 +982,16 @@
      * @returns {Promise<Object>} Resolves with the connected connection.
      */
     function mainConnection(conn) {
+      var connPromise = conn.connect();
+
+      if (clientOpts.version === 'auto') {
+        connPromise = connPromise.then(function() {
+          return negotiateProtocol(o, conn, o.getTopologyId(), clientOpts);
+        });
+      }
+
       if (o.authOpts().enabled) {
-        return conn.connect().then(function () {
+        return connPromise.then(function () {
           return authMech(o, conn, o.getTopologyId());
         }).then(function (authMechs) {
           logger.tracef(authMechs);
@@ -994,7 +1003,7 @@
         }).then(conn);
       }
 
-      return conn.connect().then(function () {
+      return connPromise.then(function () {
         return ping(o, conn,  o.getTopologyId());
       }).then(conn);
     }
@@ -1041,6 +1050,49 @@
       var p = transport.getProtocol();
       f.actions(p.stepsHeader(ctx, 0x17, undefined), codec.bytesEncoded)(ctx);
       return transport.writeCommandPinned(ctx, p.decodePingResponse, conn);
+    }
+
+    /**
+     * Negotiates the highest protocol version supported by the server.
+     * Tries versions in descending order, starting from the highest.
+     * @param {Object} transport - The transport instance.
+     * @param {Object} conn - The connection to negotiate on.
+     * @param {number} topologyId - Current topology ID.
+     * @param {Object} cOpts - Client configuration options.
+     * @returns {Promise<string>} Resolves with the negotiated version string.
+     */
+    function negotiateProtocol(transport, conn, topologyId, cOpts) {
+      var versions = protocols.VERSION_ORDER;
+
+      /**
+       * @param {number} index Version index to try.
+       * @returns {Promise<string>} Resolves with negotiated version.
+       */
+      function tryVersion(index) {
+        if (index >= versions.length)
+          return Promise.reject(new Error('No compatible protocol version found'));
+
+        var version = versions[index];
+        var candidateProtocol = protocols.resolve(version, cOpts);
+
+        transport.setProtocol(candidateProtocol);
+
+        return ping(transport, conn, topologyId)
+          .then(function() {
+            logger.debugf('Protocol negotiation succeeded with version %s', version);
+            return version;
+          })
+          .catch(function(err) {
+            var msg = typeof err === 'string' ? err : (err && err.message) || '';
+            if (msg.indexOf('CacheNotFoundException') >= 0) {
+              return Promise.reject(err);
+            }
+            logger.debugf('Protocol version %s not supported, trying next', version);
+            return tryVersion(index + 1);
+          });
+      }
+
+      return tryVersion(0);
     }
 
     /**
@@ -1141,6 +1193,7 @@
         }
       },
       getProtocol: function() { return protocol; },
+      setProtocol: function(newProtocol) { protocol = newProtocol; },
       findRpc: function(id) { return rpcMap.get(id); },
       removeRpc: function(id) { return rpcMap.remove(id); },
       updateTopology: function(bytebuf) {

--- a/lib/listeners.js
+++ b/lib/listeners.js
@@ -144,6 +144,14 @@
           return _.isEqual(addr, listener.conn.getAddress());
         });
       },
+      /**
+       * Replaces the protocol instance used by the listener subsystem.
+       * @param {Object} newProtocol Replacement protocol instance.
+       * @returns {void}
+       */
+      setProtocol: function(newProtocol) {
+        protocol = newProtocol;
+      },
     };
     return listen;
   }

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -124,9 +124,20 @@
   var EncodeMixin = (function() {
     var logger = u.logger('encoder');
 
+    var VERSION_BYTE_TO_STRING = {
+      22: '2.2', 25: '2.5', 29: '2.9', 30: '3.0', 31: '3.1', 40: '4.0', 41: '4.1'
+    };
+
     return {
       buildFlags: function (opts) { // TODO: Move out to a Mixin (similar to expiry)
         return hasOptPrev(opts) ? 0x01 : 0;
+      },
+      /**
+       * Returns the protocol version as a human-readable string (e.g. '3.1').
+       * @returns {string} Protocol version string.
+       */
+      getVersionString: function() {
+        return VERSION_BYTE_TO_STRING[this.version] || String(this.version);
       },
       encodeHeader: function (op, topologyId, opts) {
         logger.tracef('Encode operation with topology id %d', topologyId);
@@ -1299,6 +1310,18 @@
     };
   }());
 
+  /**
+   * Protocol 4.0+ requires an 'otherParams' map after media types in the header.
+   * This mixin overrides stepsHeader to append the count (0 = no params).
+   */
+  var OtherParamsMixin = {
+    stepsHeader: function(ctx, op, opts) {
+      var header = this.encodeHeader(op, ctx.topologyId, opts)(ctx.id);
+      var mediaType = this.encodeMediaTypes();
+      return f.cat(header, mediaType, [codec.encodeVInt(0)]);
+    }
+  };
+
   var DecodePrevWithMetaMixin = (function() {
     /**
      * Decodes a previous value with metadata from the response buffer.
@@ -1524,6 +1547,7 @@
   _.extend(Protocol40.prototype
     , EncodeMixin
     , ExpiryEncodeMixin
+    , OtherParamsMixin
     , DecodeMixin
     , DecodePrevWithMetaMixin
     , IdsMixin
@@ -1541,6 +1565,7 @@
   _.extend(Protocol41.prototype
     , EncodeMixin
     , ExpiryEncodeMixin
+    , OtherParamsMixin
     , DecodeMixin
     , DecodePrevWithMetaMixin
     , IdsMixin
@@ -1582,6 +1607,29 @@
 
   exports.version41 = function(clientOpts) {
     return new Protocol41(clientOpts);
+  };
+
+  var VERSION_ORDER = ['4.1', '4.0', '3.1', '3.0', '2.9', '2.5', '2.2'];
+
+  exports.VERSION_ORDER = VERSION_ORDER;
+
+  /**
+   * Creates a protocol instance for the given version string.
+   * @param {string} version Protocol version (e.g. '3.1', '4.0').
+   * @param {Object} clientOpts Client configuration options.
+   * @returns {Object} Protocol instance.
+   */
+  exports.resolve = function(version, clientOpts) {
+    switch (version) {
+      case '4.1': return new Protocol41(clientOpts);
+      case '4.0': return new Protocol40(clientOpts);
+      case '3.1': return new Protocol31(clientOpts);
+      case '3.0': return new Protocol30(clientOpts);
+      case '2.9': return new Protocol29(clientOpts);
+      case '2.5': return new Protocol25(clientOpts);
+      case '2.2': return new Protocol22(clientOpts);
+      default: throw new Error(`Unknown protocol version: ${version}`);
+    }
   };
 
 }.call(this));

--- a/run-docker-testsuite.sh
+++ b/run-docker-testsuite.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+COMPOSE_PROJECT="ispn-test"
+
+# Always tear down on exit
+cleanup() {
+  echo "Tearing down Docker containers..."
+  docker compose -p "$COMPOSE_PROJECT" --profile failover down --remove-orphans 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ── Step 1: Generate SSL certificates if needed ─────────────────────────
+if [ ! -f "out/ssl/server/server.p12" ]; then
+  echo "Generating SSL certificates..."
+  ./make-ssl.sh
+fi
+
+# ── Step 2: Start containers ────────────────────────────────────────────
+echo "Starting Infinispan containers..."
+docker compose -p "$COMPOSE_PROJECT" up -d --wait
+docker compose -p "$COMPOSE_PROJECT" --profile failover create server-failover-one server-failover-two server-failover-three
+
+# ── Step 3: Detect container IPs ────────────────────────────────────────
+get_container_ip() {
+  docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1"
+}
+
+export ISPN_LOCAL_HOST=$(get_container_ip ispn-local)
+export ISPN_CLUSTER1_HOST=$(get_container_ip ispn-cluster-1)
+export ISPN_CLUSTER2_HOST=$(get_container_ip ispn-cluster-2)
+export ISPN_CLUSTER3_HOST=$(get_container_ip ispn-cluster-3)
+export ISPN_SSL_HOST=$(get_container_ip ispn-ssl)
+export ISPN_EARTH_HOST=$(get_container_ip ispn-earth)
+export ISPN_MOON_HOST=$(get_container_ip ispn-moon)
+export ISPN_FAILOVER1_HOST=$(get_container_ip ispn-failover-1)
+export ISPN_FAILOVER2_HOST=$(get_container_ip ispn-failover-2)
+export ISPN_FAILOVER3_HOST=$(get_container_ip ispn-failover-3)
+export ISPN_DOCKER=true
+
+echo "Container IPs:"
+echo "  local:    $ISPN_LOCAL_HOST"
+echo "  cluster:  $ISPN_CLUSTER1_HOST, $ISPN_CLUSTER2_HOST, $ISPN_CLUSTER3_HOST"
+echo "  ssl:      $ISPN_SSL_HOST"
+echo "  failover: $ISPN_FAILOVER1_HOST, $ISPN_FAILOVER2_HOST, $ISPN_FAILOVER3_HOST"
+echo "  earth:    $ISPN_EARTH_HOST"
+echo "  moon:     $ISPN_MOON_HOST"
+
+# ── Step 4: Wait for cluster to form ────────────────────────────────────
+echo "Waiting for cluster to form..."
+MAX_RETRIES=30
+for i in $(seq 1 $MAX_RETRIES); do
+  CLUSTER_SIZE=$(curl -sf --digest -u admin:pass "http://$ISPN_CLUSTER1_HOST:11222/rest/v2/container" 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('cluster_size',0))" 2>/dev/null || echo "0")
+  if [ "$CLUSTER_SIZE" = "3" ]; then
+    echo "Cluster formed with 3 nodes."
+    break
+  fi
+  if [ "$i" = "$MAX_RETRIES" ]; then
+    echo "ERROR: Cluster did not form within timeout (size=$CLUSTER_SIZE)"
+    exit 1
+  fi
+  echo "  Cluster size: $CLUSTER_SIZE (attempt $i/$MAX_RETRIES)"
+  sleep 5
+done
+
+# ── Step 5: Run tests ──────────────────────────────────────────────────
+echo "Running tests..."
+npx jasmine "$@"

--- a/spec/configs/clean/infinispan.xml
+++ b/spec/configs/clean/infinispan.xml
@@ -1,7 +1,7 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:16.1 http://www.infinispan.org/schemas/infinispan-config-12.0.xsd
-                            urn:infinispan:server:16.1 http://www.infinispan.org/schemas/infinispan-server-12.0.xsd"
+        xsi:schemaLocation="urn:infinispan:config:16.1 https://infinispan.org/schemas/infinispan-config-16.1.xsd
+                            urn:infinispan:server:16.1 https://infinispan.org/schemas/infinispan-server-16.1.xsd"
         xmlns="urn:infinispan:config:16.1"
         xmlns:server="urn:infinispan:server:16.1">
 

--- a/spec/configs/docker/infinispan-clustered.xml
+++ b/spec/configs/docker/infinispan-clustered.xml
@@ -5,12 +5,16 @@
         xmlns="urn:infinispan:config:16.1"
         xmlns:server="urn:infinispan:server:16.1">
 
+    <jgroups>
+        <stack name="docker-tcp" extends="tcp">
+            <dns.DNS_PING dns_query="${jgroups.dns.query:cluster-dns-ping}"
+                          stack.combine="REPLACE"
+                          stack.position="MPING"/>
+        </stack>
+    </jgroups>
+
     <cache-container name="clustered" default-cache="default" statistics="true">
-<!--        <security>-->
-<!--            <authorization/>-->
-<!--        </security>-->
-        <transport cluster="${infinispan.cluster.name:cluster}" stack="${infinispan.cluster.stack:tcp}" node-name="${infinispan.node.name:}"/>
-        <!--<global-state/>-->
+        <transport cluster="${infinispan.cluster.name:cluster}" stack="docker-tcp" node-name="${infinispan.node.name:}"/>
         <metrics accurate-size="true"/>
         <distributed-cache name="default" segments="20" remote-timeout="30000" statistics="true">
             <locking acquire-timeout="30000" concurrency-level="1000" />
@@ -21,7 +25,7 @@
     <server xmlns="urn:infinispan:server:16.1">
         <interfaces>
             <interface name="public">
-                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+                <inet-address value="${infinispan.bind.address:0.0.0.0}"/>
             </interface>
         </interfaces>
 
@@ -32,14 +36,6 @@
         <security>
             <security-realms>
                 <security-realm name="default">
-                    <!-- Uncomment to enable TLS on the realm -->
-                    <!-- server-identities>
-                       <ssl>
-                          <keystore path="application.keystore" relative-to="infinispan.server.config.path"
-                                    password="password" alias="server" key-password="password"
-                                    generate-self-signed-certificate-host="localhost"/>
-                       </ssl>
-                    </server-identities-->
                     <properties-realm groups-attribute="Roles">
                         <user-properties path="users.properties" relative-to="infinispan.server.config.path" plain-text="true"/>
                         <group-properties path="groups.properties" relative-to="infinispan.server.config.path" />
@@ -48,7 +44,7 @@
             </security-realms>
         </security>
 
-	<endpoints>
+        <endpoints>
             <endpoint socket-binding="default" security-realm="default">
                 <hotrod-connector name="hotrod">
                     <authentication>

--- a/spec/configs/docker/infinispan-xsite-EARTH.xml
+++ b/spec/configs/docker/infinispan-xsite-EARTH.xml
@@ -9,18 +9,23 @@
 
     <jgroups>
         <stack name="bridge" extends="tcp">
+            <TCPPING initial_hosts="${jgroups.bridge.hosts:}"
+                     stack.combine="REPLACE"
+                     stack.position="MPING"
+                     xmlns="urn:org:jgroups"/>
             <FD_SOCK2 port_range="50"
                       ispn:stack.combine="COMBINE"
                       xmlns="urn:org:jgroups"/>
-            <MPING mcast_port="${jgroups.bridge.mcast_port:47655}"
-                   ispn:stack.combine="COMBINE"
-                   xmlns="urn:org:jgroups"/>
         </stack>
-        <stack name="cluster" extends="udp">
+        <stack name="cluster" extends="tcp">
+            <dns.DNS_PING dns_query="${jgroups.dns.query:earth-dns-ping}"
+                          stack.combine="REPLACE"
+                          stack.position="MPING"
+                          xmlns="urn:org:jgroups"/>
             <FD_SOCK2 port_range="50"
                       ispn:stack.combine="COMBINE"
                       xmlns="urn:org:jgroups"/>
-            <relay.RELAY2 site="MOON"
+            <relay.RELAY2 site="EARTH"
                           xmlns="urn:org:jgroups"/>
             <remote-sites default-stack="bridge">
                 <remote-site name="EARTH"/>
@@ -30,7 +35,7 @@
     </jgroups>
 
     <cache-container name="clustered">
-        <transport cluster="cluster-moon" stack="cluster"/>
+        <transport cluster="cluster-earth" stack="cluster"/>
         <security>
             <authorization/>
         </security>
@@ -38,9 +43,7 @@
         <distributed-cache name="xsiteCache" segments="20" remote-timeout="30000">
             <locking acquire-timeout="30000" concurrency-level="1000"/>
             <backups>
-                <backup site="EARTH" strategy="SYNC" timeout="3000">
-                    <state-transfer chunk-size="098" timeout="7654" max-retries="321" wait-time="0101"/>
-                </backup>
+                <backup site="MOON" strategy="SYNC" timeout="3000"/>
             </backups>
             <encoding media-type="text/plain"/>
         </distributed-cache>
@@ -49,7 +52,7 @@
     <server xmlns="urn:infinispan:server:16.1">
         <interfaces>
             <interface name="public">
-                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+                <inet-address value="${infinispan.bind.address:0.0.0.0}"/>
             </interface>
         </interfaces>
 

--- a/spec/configs/docker/infinispan-xsite-MOON.xml
+++ b/spec/configs/docker/infinispan-xsite-MOON.xml
@@ -9,14 +9,19 @@
 
     <jgroups>
         <stack name="bridge" extends="tcp">
+            <TCPPING initial_hosts="${jgroups.bridge.hosts:}"
+                     stack.combine="REPLACE"
+                     stack.position="MPING"
+                     xmlns="urn:org:jgroups"/>
             <FD_SOCK2 port_range="50"
                       ispn:stack.combine="COMBINE"
                       xmlns="urn:org:jgroups"/>
-            <MPING mcast_port="${jgroups.bridge.mcast_port:47655}"
-                   ispn:stack.combine="COMBINE"
-                   xmlns="urn:org:jgroups"/>
         </stack>
-        <stack name="cluster" extends="udp">
+        <stack name="cluster" extends="tcp">
+            <dns.DNS_PING dns_query="${jgroups.dns.query:moon-dns-ping}"
+                          stack.combine="REPLACE"
+                          stack.position="MPING"
+                          xmlns="urn:org:jgroups"/>
             <FD_SOCK2 port_range="50"
                       ispn:stack.combine="COMBINE"
                       xmlns="urn:org:jgroups"/>
@@ -49,7 +54,7 @@
     <server xmlns="urn:infinispan:server:16.1">
         <interfaces>
             <interface name="public">
-                <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+                <inet-address value="${infinispan.bind.address:0.0.0.0}"/>
             </interface>
         </interfaces>
 

--- a/spec/configs/infinispan-ssl.xml
+++ b/spec/configs/infinispan-ssl.xml
@@ -1,7 +1,7 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:16.1 https://infinispan.org/schemas/infinispan-config-13.0.xsd
-                            urn:infinispan:server:16.1 https://infinispan.org/schemas/infinispan-server-13.0.xsd"
+        xsi:schemaLocation="urn:infinispan:config:16.1 https://infinispan.org/schemas/infinispan-config-16.1.xsd
+                            urn:infinispan:server:16.1 https://infinispan.org/schemas/infinispan-server-16.1.xsd"
         xmlns="urn:infinispan:config:16.1"
         xmlns:server="urn:infinispan:server:16.1">
 

--- a/spec/configs/infinispan-xsite-EARTH.xml
+++ b/spec/configs/infinispan-xsite-EARTH.xml
@@ -1,11 +1,11 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:16.0 https://infinispan.org/schemas/infinispan-config-16.0.xsd
-                            urn:infinispan:server:16.0 https://infinispan.org/schemas/infinispan-server-16.0.xsd
+        xsi:schemaLocation="urn:infinispan:config:16.1 https://infinispan.org/schemas/infinispan-config-16.1.xsd
+                            urn:infinispan:server:16.1 https://infinispan.org/schemas/infinispan-server-16.1.xsd
                             urn:org:jgroups http://www.jgroups.org/schema/jgroups-5.5.xsd"
-        xmlns="urn:infinispan:config:16.0"
-        xmlns:ispn="urn:infinispan:config:16.0"
-        xmlns:server="urn:infinispan:server:16.0">
+        xmlns="urn:infinispan:config:16.1"
+        xmlns:ispn="urn:infinispan:config:16.1"
+        xmlns:server="urn:infinispan:server:16.1">
 
     <jgroups>
         <stack name="bridge" extends="tcp">
@@ -44,7 +44,7 @@
         </distributed-cache>
     </cache-container>
 
-    <server xmlns="urn:infinispan:server:16.0">
+    <server xmlns="urn:infinispan:server:16.1">
         <interfaces>
             <interface name="public">
                 <inet-address value="${infinispan.bind.address:127.0.0.1}"/>

--- a/spec/configs/infinispan.xml
+++ b/spec/configs/infinispan.xml
@@ -1,7 +1,7 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:infinispan:config:16.1 https://infinispan.org/schemas/infinispan-config-16.0.xsd
-                            urn:infinispan:server:16.1 https://infinispan.org/schemas/infinispan-server-16.0.xsd"
+        xsi:schemaLocation="urn:infinispan:config:16.1 https://infinispan.org/schemas/infinispan-config-16.1.xsd
+                            urn:infinispan:server:16.1 https://infinispan.org/schemas/infinispan-server-16.1.xsd"
         xmlns="urn:infinispan:config:16.1"
         xmlns:server="urn:infinispan:server:16.1">
 

--- a/spec/infinispan_failover_listener_spec.js
+++ b/spec/infinispan_failover_listener_spec.js
@@ -5,7 +5,7 @@ describe('Infinispan clustered clients with listeners', function() {
 
   it('can failover when nodes crash', function(done) {
     var keys = ['before-failover-listener', 'middle-failover-listener', 'after-failover-listener'];
-    t.launchClusterNodeAndWaitView('server-failover-one', t.failoverConfig, t.failover1['port'], t.failoverMCastAddr, 1, t.client)
+    t.launchClusterNodeAndWaitView('server-failover-one', t.failoverConfig, t.failover1, t.failoverMCastAddr, 1, t.client)
        .then(function() {
          return t.client(t.failover1, t.authOpts);
        })
@@ -13,13 +13,13 @@ describe('Infinispan clustered clients with listeners', function() {
       .then(t.assert(t.clear()))
       .then(t.on('create', t.expectEvents(keys, done, true)))
       .then(t.assert(t.putIfAbsent(keys[0], 'value'), t.toBeTruthy))
-      .then(function(client) {return t.launchClusterNodeAndWaitView('server-failover-two', t.failoverConfig, t.failover2['port'], t.failoverMCastAddr, 2, client);}) //11432
+      .then(function(client) {return t.launchClusterNodeAndWaitView('server-failover-two', t.failoverConfig, t.failover2, t.failoverMCastAddr, 2, client);}) //11432
       .then(expectClientView([t.failover1, t.failover2]))
       .then(t.assert(t.putIfAbsent(keys[1], 'value'), t.toBeTruthy))
-      .then(withAll(t.stopAndWaitView(t.failover1['port'], 1, t.failover2['port'])))
+      .then(withAll(t.stopAndWaitView(t.failover1, 1, t.failover2)))
       .then(expectClientView([t.failover2]))
       .then(t.assert(t.putIfAbsent(keys[2], 'value'), t.toBeTruthy))
-      .then(withAll(t.stopClusterNode(t.failover2['port'], true)))
+      .then(withAll(t.stopClusterNode(t.failover2, true)))
       .then(withAll(t.disconnect()))
       .catch(t.failed(done));
   }, 120000);

--- a/spec/infinispan_failover_spec.js
+++ b/spec/infinispan_failover_spec.js
@@ -3,26 +3,26 @@ var t = require('./utils/testing'); // Testing dependency
 describe('Infinispan clustered clients', function() {
 
   it('can failover when nodes crash', function(done) {
-      t.launchClusterNodeAndWaitView('server-failover-one', t.failoverConfig, t.failover1['port'], t.failoverMCastAddr, 1)
+      t.launchClusterNodeAndWaitView('server-failover-one', t.failoverConfig, t.failover1, t.failoverMCastAddr, 1)
           .then(function() {
               return t.client(t.failover1,  t.authOpts);
           })
           .then(t.assert(t.getMembers(), t.toContain([t.failover1])))
           .then(function(client) {
-            return t.launchClusterNodeAndWaitView('server-failover-two', t.failoverConfig, t.failover2['port'], t.failoverMCastAddr,  2, client);}) //11432
+            return t.launchClusterNodeAndWaitView('server-failover-two', t.failoverConfig, t.failover2, t.failoverMCastAddr,  2, client);}) //11432
           .then(expectClientView([t.failover1, t.failover2]))
-          .then(function(client) { return t.launchClusterNodeAndWaitView('server-failover-three', t.failoverConfig, t.failover3['port'], t.failoverMCastAddr, 3, client); }) //11442
+          .then(function(client) { return t.launchClusterNodeAndWaitView('server-failover-three', t.failoverConfig, t.failover3, t.failoverMCastAddr, 3, client); }) //11442
           .then(expectClientView([t.failover1, t.failover2, t.failover3]))
           .then(keyGen([t.failover2, t.failover3]))
           .then(withAll(keyPut('failover-value')))
           .then(withAll(keyGet(t.toBe('failover-value'))))
-          .then(withFirst(t.stopAndWaitView(t.failover3['port'], 2, t.failover1['port'])))
+          .then(withFirst(t.stopAndWaitView(t.failover3, 2, t.failover1)))
           .then(withFirst(expectClientView([t.failover1, t.failover2])))
           .then(withAll(keyGet(t.toBe('failover-value'))))
-          .then(withFirst(t.stopAndWaitView(t.failover2['port'], 1, t.failover1['port'])))
+          .then(withFirst(t.stopAndWaitView(t.failover2, 1, t.failover1)))
           .then(withFirst(expectClientView([t.failover1])))
           .then(withAll(keyGet(t.toBe('failover-value'))))
-          .then(withFirst(t.stopClusterNode(t.failover1['port'], false)))
+          .then(withFirst(t.stopClusterNode(t.failover1, false)))
           .then(withFirst(t.disconnect()))
           .then(function() { done(); }, t.failed(done));
   }, 120000);

--- a/spec/infinispan_json_spec.js
+++ b/spec/infinispan_json_spec.js
@@ -32,17 +32,17 @@ describe('Infinispan JSON client', function() {
     it('can return previous values', function (done) {
       client
         .then(t.assert(t.putIfAbsent({k: 'jprev'}, {v: 'jv0'}, t.prev()), t.toBeUndefined))
-        .then(t.assert(t.putIfAbsent({k: 'jprev'}, {v: 'jv1'}, t.prev()), t.toEqual({v: 'jv0'})))
-        .then(t.assert(t.remove({k: 'jprev'}, t.prev()), t.toEqual({v: 'jv0'})))
+        .then(t.assert(t.putIfAbsent({k: 'jprev'}, {v: 'jv1'}, t.prev()), t.toEqualPrevOf({v: 'jv0'})))
+        .then(t.assert(t.remove({k: 'jprev'}, t.prev()), t.toEqualPrevOf({v: 'jv0'})))
         .then(t.assert(t.put({k: 'jprev'}, {v: 'jv1'}, t.prev()), t.toBeUndefined))
-        .then(t.assert(t.put({k: 'jprev'}, {v: 'jv2'}, t.prev()), t.toEqual({v: 'jv1'})))
-        .then(t.assert(t.replace({k: 'jprev'}, {v: 'jv3'}, t.prev()), t.toEqual({v: 'jv2'})))
+        .then(t.assert(t.put({k: 'jprev'}, {v: 'jv2'}, t.prev()), t.toEqualPrevOf({v: 'jv1'})))
+        .then(t.assert(t.replace({k: 'jprev'}, {v: 'jv3'}, t.prev()), t.toEqualPrevOf({v: 'jv2'})))
         .then(t.assert(
           t.conditional(t.replaceV, t.getM, {k: 'jprev'}, {v: 'jv3'}, {v: 'jv4'}, t.prev())
-          , t.toEqual({v: 'jv3'})))
+          , t.toEqualPrevOf({v: 'jv3'})))
         .then(t.assert(
           t.conditional(t.removeWithVersion, t.getM, {k: 'jprev'}, {v: 'jv4'}, t.prev())
-          , t.toEqual({v: 'jv4'})))
+          , t.toEqualPrevOf({v: 'jv4'})))
         .then(function() { done(); }, t.failed(done));
     });
     it('can use multi-key operations', function (done) {

--- a/spec/infinispan_local_spec.js
+++ b/spec/infinispan_local_spec.js
@@ -47,19 +47,19 @@ describe('Infinispan local client', function() {
   });
   it('can return previous values', function(done) { client
     .then(t.assert(t.putIfAbsent('prev', 'v0', t.prev()), t.toBeUndefined))
-    .then(t.assert(t.putIfAbsent('prev', 'v1', t.prev()), t.toBe('v0')))
-    .then(t.assert(t.remove('prev', t.prev()), t.toBe('v0')))
+    .then(t.assert(t.putIfAbsent('prev', 'v1', t.prev()), t.toBePrevOf('v0')))
+    .then(t.assert(t.remove('prev', t.prev()), t.toBePrevOf('v0')))
     .then(t.assert(t.remove('prev', t.prev()), t.toBeUndefined))
     .then(t.assert(t.put('prev', 'v1', t.prev()), t.toBeUndefined))
-    .then(t.assert(t.put('prev', 'v2', t.prev()), t.toBe('v1')))
-    .then(t.assert(t.replace('prev', 'v3', t.prev()), t.toBe('v2')))
+    .then(t.assert(t.put('prev', 'v2', t.prev()), t.toBePrevOf('v1')))
+    .then(t.assert(t.replace('prev', 'v3', t.prev()), t.toBePrevOf('v2')))
     .then(t.assert(t.replace('_', 'v3', t.prev()), t.toBeUndefined))
-    .then(t.assert(t.conditional(t.replaceV, t.getM, 'prev', 'v3', 'v4', t.prev()), t.toBe('v3')))
+    .then(t.assert(t.conditional(t.replaceV, t.getM, 'prev', 'v3', 'v4', t.prev()), t.toBePrevOf('v3')))
     .then(t.assert(t.notReplaceWithVersion('_', t.prev()), t.toBeUndefined)) // key not found
-    .then(t.assert(t.notReplaceWithVersion('prev', t.prev()), t.toBe('v4'))) // key found but invalid version
+    .then(t.assert(t.notReplaceWithVersion('prev', t.prev()), t.toBePrevOf('v4'))) // key found but invalid version
     .then(t.assert(t.notRemoveWithVersion('_', t.prev()), t.toBeUndefined)) // key not found
-    .then(t.assert(t.notRemoveWithVersion('prev', t.prev()), t.toBe('v4'))) // key found but invalid version
-    .then(t.assert(t.conditional(t.removeWithVersion, t.getM, 'prev', 'v4', t.prev()), t.toBe('v4')))
+    .then(t.assert(t.notRemoveWithVersion('prev', t.prev()), t.toBePrevOf('v4'))) // key found but invalid version
+    .then(t.assert(t.conditional(t.removeWithVersion, t.getM, 'prev', 'v4', t.prev()), t.toBePrevOf('v4')))
     .then(function() { done(); }, t.failed(done));
   });
   it('can use multi-key operations', function(done) {

--- a/spec/infinispan_negotiate_spec.js
+++ b/spec/infinispan_negotiate_spec.js
@@ -1,0 +1,41 @@
+var t = require('./utils/testing'); // Testing dependency
+var ispn = require('../lib/infinispan');
+var protocols = require('../lib/protocols');
+
+describe('Protocol auto-negotiation', function() {
+  t.configureLogging();
+
+  it('should negotiate a supported protocol version', function(done) {
+    ispn.client(t.local, {version: 'auto', authentication: t.authOpts.authentication})
+      .then(function(client) {
+        var version = client.getProtocolVersion();
+        expect(version).toBeDefined();
+        expect(protocols.VERSION_ORDER).toContain(version);
+        return client.disconnect();
+      })
+      .then(function() { done(); }, t.failed(done));
+  });
+
+  it('should perform basic operations after negotiation', function(done) {
+    ispn.client(t.local, {version: 'auto', authentication: t.authOpts.authentication})
+      .then(function(client) {
+        return client.put('neg-key', 'neg-value')
+          .then(function() { return client.get('neg-key'); })
+          .then(function(v) {
+            expect(v).toBe('neg-value');
+          })
+          .then(function() { return client.remove('neg-key'); })
+          .then(function() { return client.disconnect(); });
+      })
+      .then(function() { done(); }, t.failed(done));
+  });
+
+  it('should report correct version with explicit protocol', function(done) {
+    ispn.client(t.local, {version: '3.1', authentication: t.authOpts.authentication})
+      .then(function(client) {
+        expect(client.getProtocolVersion()).toBe('3.1');
+        return client.disconnect();
+      })
+      .then(function() { done(); }, t.failed(done));
+  });
+});

--- a/spec/infinispan_ssl_spec.js
+++ b/spec/infinispan_ssl_spec.js
@@ -111,7 +111,8 @@ describe('Infinispan TLS/SSL client', function() {
       ssl: {
         enabled: true,
         secureProtocol: 'TLS_client_method',
-        trustCerts: ['out/ssl/ca/ca.pem']
+        trustCerts: ['out/ssl/ca/ca.pem'],
+        sniHostName: t.isDocker ? 'localhost' : undefined
       },
       authentication: {
         enabled: true,
@@ -134,7 +135,8 @@ describe('Infinispan TLS/SSL client', function() {
         cryptoStore: {
           path: 'out/ssl/client/client.p12',
           passphrase: 'secret'
-        }
+        },
+        sniHostName: t.isDocker ? 'localhost' : undefined
       },
       authentication: {
         enabled: true,
@@ -158,7 +160,8 @@ describe('Infinispan TLS/SSL client', function() {
             key: 'out/ssl/client/client.pk',
             passphrase: 'secret',
             cert: 'out/ssl/client/client.pem'
-          }
+          },
+          sniHostName: t.isDocker ? 'localhost' : undefined
         },
         authentication: {
           enabled: true,

--- a/spec/infinispan_xsite_spec.js
+++ b/spec/infinispan_xsite_spec.js
@@ -11,8 +11,8 @@ describe('Infinispan xsite cluster client', function() {
   // any cleanup as first test so that it only gets executed once.
   it('start sites', function(done) {
       logger.debugf('Waiting for xsite servers to be ready.');
-      t.waitUntilView(1, t.earth1['port'])
-          .then(function() { return t.waitUntilView(1, t.moon1['port']); })
+      t.waitUntilView(1, t.earth1)
+          .then(function() { return t.waitUntilView(1, t.moon1); })
           .then(function () {
             logger.debugf('Both moon and earth servers started');
           }).then(function() { done(); }, t.failed(done));
@@ -33,7 +33,7 @@ describe('Infinispan xsite cluster client', function() {
         })
         .then(assertGet('xsite-key', 'xsite-value', cs[0]))
         .then(assertGet('xsite-key', 'xsite-value', cs[1]))
-        .then(t.stopClusterNode(t.earth1['port'], true))
+        .then(t.stopClusterNode(t.earth1, true))
         // Client connected to surviving site should find data
         .then(assertGet('xsite-key', 'xsite-value', cs[1]))
         // Client connected to crashed site should failover
@@ -44,8 +44,8 @@ describe('Infinispan xsite cluster client', function() {
         })
         // Re-launch site stopped site and stop alive site
         .then(assertGet('xsite-key', 'xsite-value', cs[0]))
-        .then(function(client) { return t.launchClusterNodeAndWaitView('server-earth', t.earth1Config, t.earth1['port'], t.earth1MCastAddr, 1, client); })
-        .then(t.stopClusterNode(t.moon1['port'], true))
+        .then(function(client) { return t.launchClusterNodeAndWaitView('server-earth', t.earth1Config, t.earth1, t.earth1MCastAddr, 1, client); })
+        .then(t.stopClusterNode(t.moon1, true))
         // Client connected to failed over site should come back to original site
         .then(assertGet('xsite-key', undefined, cs[0]))
         .then(function() {
@@ -56,7 +56,7 @@ describe('Infinispan xsite cluster client', function() {
         })
         .then(assertGet('xsite-key-2', 'xsite-value-2', cs[0]))
           //Stopping the rest of the servers to finish the test
-        .then(t.stopClusterNode(t.earth1['port'], true))
+        .then(t.stopClusterNode(t.earth1, true))
         .finally(function() {
           return Promise.all(_.map(cs, function(c) { return c.disconnect(); }));
         });

--- a/spec/utils/testing.js
+++ b/spec/utils/testing.js
@@ -15,6 +15,8 @@ var protocols = require('../../lib/protocols');
 
 exports.serverDirName = 'infinispan-server';
 
+exports.isDocker = process.env.ISPN_DOCKER === 'true';
+
 exports.authOpts = {
   authentication: {
     enabled: true,
@@ -24,26 +26,36 @@ exports.authOpts = {
   }
 };
 
-exports.local = {port: 11222, host: '127.0.0.1'};
-
-exports.cluster1 = {port: 11322, host: '127.0.0.1'};
-exports.cluster2 = {port: 11332, host: '127.0.0.1'};
-exports.cluster3 = {port: 11342, host: '127.0.0.1'};
+if (exports.isDocker) {
+  // Docker mode: all containers listen on port 11222, IPs detected via env vars
+  exports.local = {port: 11222, host: process.env.ISPN_LOCAL_HOST};
+  exports.cluster1 = {port: 11222, host: process.env.ISPN_CLUSTER1_HOST};
+  exports.cluster2 = {port: 11222, host: process.env.ISPN_CLUSTER2_HOST};
+  exports.cluster3 = {port: 11222, host: process.env.ISPN_CLUSTER3_HOST};
+  exports.failover1 = {port: 11222, host: process.env.ISPN_FAILOVER1_HOST};
+  exports.failover2 = {port: 11222, host: process.env.ISPN_FAILOVER2_HOST};
+  exports.failover3 = {port: 11222, host: process.env.ISPN_FAILOVER3_HOST};
+  exports.ssl = {port: 11232, host: process.env.ISPN_SSL_HOST};
+  exports.earth1 = {port: 11222, host: process.env.ISPN_EARTH_HOST};
+  exports.moon1 = {port: 11222, host: process.env.ISPN_MOON_HOST};
+} else {
+  // Local mode: servers on localhost with different ports
+  exports.local = {port: 11222, host: '127.0.0.1'};
+  exports.cluster1 = {port: 11322, host: '127.0.0.1'};
+  exports.cluster2 = {port: 11332, host: '127.0.0.1'};
+  exports.cluster3 = {port: 11342, host: '127.0.0.1'};
+  exports.failover1 = {port: 11422, host: '127.0.0.1'};
+  exports.failover2 = {port: 11432, host: '127.0.0.1'};
+  exports.failover3 = {port: 11442, host: '127.0.0.1'};
+  // SSL invocations directed to 'localhost' for TLS server name matching
+  exports.ssl = {port: 11232, host: 'localhost'};
+  exports.earth1 = {port: 11522, host: '127.0.0.1'};
+  exports.moon1 = {port: 11532, host: '127.0.0.1'};
+}
 exports.cluster = [exports.cluster1, exports.cluster2, exports.cluster3];
-
-exports.failover1 = {port: 11422, host: '127.0.0.1'};
-exports.failover2 = {port: 11432, host: '127.0.0.1'};
-exports.failover3 = {port: 11442, host: '127.0.0.1'};
 exports.failoverConfig = 'infinispan-clustered.xml';
-exports.failoverMCastAddr= '234.99.64.14';
-
-// All ssl invocations needs to be directed to localhost instead of 127.0.0.1
-// because Node.js uses `localhost` as default server name if none provided.
-exports.ssl = {port: 11232, host: 'localhost'};
-
+exports.failoverMCastAddr = '234.99.64.14';
 exports.xsiteCacheName = 'xsiteCache';
-exports.earth1 = {port: 11522, host: '127.0.0.1'};
-exports.moon1 = {port: 11532, host: '127.0.0.1'};
 exports.earth1Config = 'infinispan-xsite-EARTH.xml';
 exports.moon1Config = 'infinispan-xsite-MOON.xml';
 exports.earth1MCastAddr = '234.99.74.14';
@@ -311,7 +323,8 @@ exports.toEqual = function(value) {
 
 exports.toContain = function(value) {
   return function(actual) {
-    if (_.isObject(value)) expect(actual).toEqual(jasmine.objectContaining(value));
+    if (_.isArray(value)) expect(actual).toEqual(jasmine.arrayContaining(value));
+    else if (_.isObject(value)) expect(actual).toEqual(jasmine.objectContaining(value));
     else expect(actual).toContain(value);
   };
 };
@@ -560,6 +573,33 @@ exports.prev = function() {
   return { previous: true };
 };
 
+/**
+ * Extracts the plain value from a previous-value response.
+ * On protocol < 4.0, prev is the raw value (string or object).
+ * On protocol 4.0+, prev is {value, version, created, lifespan, lastUsed, maxIdle}.
+ * @param {*} prev The previous value response.
+ * @returns {*} The extracted value.
+ */
+exports.prevValue = function(prev) {
+  if (!f.existy(prev)) return undefined;
+  if (_.isObject(prev) && prev.version !== undefined) return prev.value;
+  return prev;
+};
+
+exports.toBePrevOf = function(value) {
+  return function(actual) {
+    var extracted = exports.prevValue(actual);
+    expect(extracted).toBe(value);
+  };
+};
+
+exports.toEqualPrevOf = function(value) {
+  return function(actual) {
+    var extracted = exports.prevValue(actual);
+    expect(extracted).toEqual(value);
+  };
+};
+
 exports.counterCreate = function(name, config) {
   return function(client) { return client.counterCreate(name, config); };
 };
@@ -610,45 +650,123 @@ exports.getHotrodProtocolVersion = function() {
   return version;
 };
 
-exports.stopClusterNode = function(port, waitStop) {
+// Map address objects to Docker container names for lifecycle management
+var addrToContainer = new Map();
+function initAddrToContainer() {
+  if (addrToContainer.size > 0) return;
+  addrToContainer.set(exports.local, 'ispn-local');
+  addrToContainer.set(exports.cluster1, 'ispn-cluster-1');
+  addrToContainer.set(exports.cluster2, 'ispn-cluster-2');
+  addrToContainer.set(exports.cluster3, 'ispn-cluster-3');
+  addrToContainer.set(exports.failover1, 'ispn-failover-1');
+  addrToContainer.set(exports.failover2, 'ispn-failover-2');
+  addrToContainer.set(exports.failover3, 'ispn-failover-3');
+  addrToContainer.set(exports.earth1, 'ispn-earth');
+  addrToContainer.set(exports.moon1, 'ispn-moon');
+}
+
+// Normalize an addr-or-port argument to {host, port}
+function resolveAddr(addrOrPort) {
+  if (typeof addrOrPort === 'object') return addrOrPort;
+  // Legacy: bare port number — scan exports for a matching port
+  var all = [exports.local, exports.cluster1, exports.cluster2, exports.cluster3,
+    exports.failover1, exports.failover2, exports.failover3,
+    exports.ssl, exports.earth1, exports.moon1];
+  for (var i = 0; i < all.length; i++) {
+    if (all[i].port === addrOrPort) return all[i];
+  }
+  return {host: '127.0.0.1', port: addrOrPort};
+}
+
+function containerForAddr(addrOrPort) {
+  initAddrToContainer();
+  var addr = resolveAddr(addrOrPort);
+  // Direct identity match first (for address objects passed by reference)
+  if (addrToContainer.has(addr)) return addrToContainer.get(addr);
+  // Fallback: match by host
+  for (var [a, container] of addrToContainer) {
+    if (a.host === addr.host) return container;
+  }
+  return undefined;
+}
+
+exports.stopClusterNode = function(addrOrPort, waitStop) {
   return function() {
+    if (exports.isDocker) {
+      return stopDockerContainer(addrOrPort, waitStop);
+    }
+    var addr = resolveAddr(addrOrPort);
     var opUrl = '/server?action=stop';
 
     if (waitStop) {
-      return invokeDmrHttpGet('POST', opUrl, port).then(function() {
-        return waitUntilStopped(port);
+      return invokeDmrHttpGet('POST', opUrl, addr).then(function() {
+        return waitUntilStopped(addr);
       }).catch(function (err) {
         console.log(`Error stopping ${   err}`);
-        return Promise.resolve(`unable to stop server in port ${  port}`);
+        return Promise.resolve(`unable to stop server at ${addr.host}:${addr.port}`);
       });
     }
 
-    return invokeDmrHttpGet('POST', opUrl, port);
+    return invokeDmrHttpGet('POST', opUrl, addr);
   };
 };
 
-function waitUntilStopped(port) {
+function stopDockerContainer(addrOrPort, waitStop) {
+  var container = containerForAddr(addrOrPort);
+  if (!container) return Promise.reject(new Error(`No Docker container mapped to ${JSON.stringify(addrOrPort)}`));
+
+  return new Promise(function(resolve) {
+    var exec = require('child_process').exec;
+    exec(`docker stop ${container}`, function(err) {
+      if (err) {
+        console.log(`Error stopping container ${container}: ${err}`);
+        return resolve(`unable to stop container ${container}`);
+      }
+      if (waitStop) {
+        exec(`docker wait ${container}`, function() {
+          resolve();
+        });
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function waitUntilStopped(addrOrPort) {
   return waitUntil(
     function(resp) { expect(resp).toEqual(0); },
     function(resp) { return _.isEqual(resp, 0); },
-    getServerStatus(port)
+    getServerStatus(addrOrPort)
   );
 }
 
-function getServerStatus(port) {
+function getServerStatus(addrOrPort) {
+  if (exports.isDocker) {
+    var container = containerForAddr(addrOrPort);
+    return function() {
+      return new Promise(function(fulfil) {
+        var exec = require('child_process').exec;
+        exec(`docker inspect -f '{{.State.Running}}' ${container} 2>/dev/null`, function(err, stdout) {
+          fulfil(stdout && stdout.trim() === 'true' ? 1 : 0);
+        });
+      });
+    };
+  }
+  var addr = resolveAddr(addrOrPort);
   return function() {
-    return new Promise(function(fulfil, reject) {
+    return new Promise(function(fulfil) {
       var spawn = require('child_process').spawn;
-      var child = spawn('fuser', [`${port  }/tcp`]);
+      var child = spawn('fuser', [`${addr.port}/tcp`]);
       var count = 0;
 
       child.stdout.on('data', function(chunk) {
-          chunk.toString().split('\n').forEach(function(_) {
+          chunk.toString().split('\n').forEach(function() {
               count++;
           });
       });
 
-      child.stdout.on('end', function(_) {
+      child.stdout.on('end', function() {
         fulfil(count);
       });
     });
@@ -662,8 +780,8 @@ exports.stopAndWaitView = function(nodeStop, expectNumMembers, nodeView) {
   };
 };
 
-exports.waitUntilView = function(expectNumMembers, port) {
-  logger.debugf('Wait until view of %d nodes on \'%s\'', expectNumMembers, port);
+exports.waitUntilView = function(expectNumMembers, addrOrPort) {
+  logger.debugf('Wait until view of %d nodes on \'%s\'', expectNumMembers, addrOrPort);
   return waitUntil(
     function(members) {
       logger.debugf(
@@ -681,11 +799,21 @@ exports.waitUntilView = function(expectNumMembers, port) {
       );
       return success;
     },
-    getClusterMembers(port)
+    getClusterMembers(addrOrPort)
   );
 };
-exports.launchClusterNodeAndWaitView = function(nodeName, config, port, mcastAddr, expectNumMembers, client) {
-    return killProcessOnPort(port).then(function() {
+exports.launchClusterNodeAndWaitView = function(nodeName, config, addrOrPort, mcastAddr, expectNumMembers, client) {
+    if (exports.isDocker) {
+      return launchDockerNode(addrOrPort).then(function() {
+        logger.debugf(`wait until view ${  expectNumMembers}`);
+        return exports.waitUntilView(expectNumMembers, addrOrPort);
+      }).then(function() {
+        logger.debugf('return client');
+        return client;
+      });
+    }
+    var addr = resolveAddr(addrOrPort);
+    return killProcessOnPort(addr.port).then(function() {
         return new Promise(function (fulfill) {
             var spawn = require('child_process').spawn;
             var path = require('path');
@@ -694,7 +822,7 @@ exports.launchClusterNodeAndWaitView = function(nodeName, config, port, mcastAdd
             var standaloneShPath = `${serverPath  }/bin/server.sh`;
             var cmd = spawn(
                 standaloneShPath,
-                ['-c', config, '-p', port, '-s',`${serverPath  }/${  nodeName}`,
+                ['-c', config, '-p', addr.port, '-s',`${serverPath  }/${  nodeName}`,
                     `-Djgroups.mcast_addr=${  mcastAddr}`,
                     `-Dinfinispan.node.name=${  nodeName}`,
                     '-Djgroups.join_timeout=1000',
@@ -713,12 +841,50 @@ exports.launchClusterNodeAndWaitView = function(nodeName, config, port, mcastAdd
         });
     }).then(function() {
         logger.debugf(`wait until view ${  expectNumMembers}`);
-        return exports.waitUntilView(expectNumMembers, port);
+        return exports.waitUntilView(expectNumMembers, addrOrPort);
     }).then(function() {
         logger.debugf('return client');
         return client;
     });
 };
+
+function launchDockerNode(addrOrPort) {
+  var container = containerForAddr(addrOrPort);
+  if (!container) return Promise.reject(new Error(`No Docker container mapped to ${JSON.stringify(addrOrPort)}`));
+  var addr = resolveAddr(addrOrPort);
+
+  return new Promise(function(resolve, reject) {
+    var exec = require('child_process').exec;
+    exec(`docker start ${container}`, function(err) {
+      if (err) return reject(err);
+      var maxRetries = 30;
+      var attempt = 0;
+      function checkHealth() {
+        exec(`docker inspect -f '{{.State.Health.Status}}' ${container} 2>/dev/null`,
+          function(checkErr, stdout) {
+            attempt++;
+            if (stdout && stdout.trim() === 'healthy') {
+              // Resolve container IP and update address object
+              exec(`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${container}`,
+                function(ipErr, ipOut) {
+                  if (!ipErr && ipOut && ipOut.trim()) {
+                    addr.host = ipOut.trim();
+                    logger.debugf('Container %s IP resolved to %s', container, addr.host);
+                  }
+                  return resolve();
+                });
+              return;
+            }
+            if (attempt >= maxRetries) {
+              return reject(new Error(`Container ${container} did not become healthy`));
+            }
+            setTimeout(checkHealth, 2000);
+          });
+      }
+      setTimeout(checkHealth, 2000);
+    });
+  });
+}
 
 function killProcessOnPort(port) {
     return new Promise(function(resolve) {
@@ -779,14 +945,14 @@ exports.sleepFor = function(sleepDuration) {
   return new Promise(function(resolve) { setTimeout(resolve, sleepDuration); });
 };
 
-function getClusterMembers(port) {
+function getClusterMembers(addrOrPort) {
 
   return function() {
     var opUrl ='/container';
 
-    return invokeDmrHttpGet('GET', opUrl, port)
+    return invokeDmrHttpGet('GET', opUrl, addrOrPort)
       .then(function(response) {
-        logger.debugf('Server %s replied with cluster members: %s', port, response.cluster_size);
+        logger.debugf('Server %s replied with cluster members: %s', addrOrPort, response.cluster_size);
         var members = response.cluster_size;
         logger.debugf('Members are: %s', members);
         return members;
@@ -859,15 +1025,24 @@ function digestRequest(method, url, username, password) {
   });
 }
 
-function invokeDmrHttp(op, port) {
-  return digestRequest('POST', `http://localhost:${port}/rest/v2`, 'admin', 'pass')
+function restHostPort(addrOrPort) {
+  var addr = resolveAddr(addrOrPort);
+  if (!exports.isDocker) return `localhost:${addr.port}`;
+  // In Docker, REST is on port 11222 at the container's IP
+  return `${addr.host}:11222`;
+}
+
+function invokeDmrHttp(op, addrOrPort) {
+  var hostPort = restHostPort(addrOrPort);
+  return digestRequest('POST', `http://${hostPort}/rest/v2`, 'admin', 'pass')
       .then(res => res.statusCode == 200 ? JSON.parse(res.data) : {},
             error => (util.format('Error (%s)', error)));
 }
 
-function invokeDmrHttpGet(method, opUrl, port) {
-  logger.debugf(`URL http://localhost:${port}/rest/v2${opUrl}`);
-  return digestRequest(method, `http://localhost:${port}/rest/v2${opUrl}`, 'admin', 'pass')
+function invokeDmrHttpGet(method, opUrl, addrOrPort) {
+  var hostPort = restHostPort(addrOrPort);
+  logger.debugf(`URL http://${hostPort}/rest/v2${opUrl}`);
+  return digestRequest(method, `http://${hostPort}/rest/v2${opUrl}`, 'admin', 'pass')
       .then(res => res.statusCode == 200 ? JSON.parse(res.data) : {},
             error => (util.format('Error (%s)', error)));
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,7 @@ export function client(args: {
     /**
      * - Version of client/server protocol.
      */
-    version?: ('4.1' | '4.0' | '3.1' | '3.0' | '2.9' | '2.5' | '2.2') | null;
+    version?: ('auto' | '4.1' | '4.0' | '3.1' | '3.0' | '2.9' | '2.5' | '2.2') | null;
     /**
      * - Optional cache name.
      */
@@ -153,6 +153,14 @@ export function client(args: {
          * @since 0.3
          */
         disconnect: () => Promise<void>;
+        /**
+         * Returns the active protocol version string (e.g. '3.1', '4.1').
+         * When using auto-negotiation, this reflects the negotiated version.
+         *
+         * @returns {string} Protocol version string.
+         * @memberof Client#
+         */
+        getProtocolVersion: () => string;
         /**
          * Get the value associated with the given key parameter.
          *


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with all 10 Infinispan server services using static IPs on a dedicated `172.30.0.0/24` subnet, with healthchecks and DNS aliases for JGroups cluster discovery
- Add `Dockerfile.server` extending the base image with Nashorn script engine for server-side script execution
- Add Docker-compatible JGroups configs using DNS_PING for cluster discovery and TCPPING for cross-site bridge communication
- Update `testing.js` to support Docker mode (`ISPN_DOCKER=true`) with static IP addresses, container lifecycle management via `docker start`/`docker stop`, and digest authentication for the REST management API
- Update spec files to pass address objects instead of bare port numbers for Docker compatibility
- Update CI workflow and add `run-docker-testsuite.sh` for local execution

Closes #138

## Test plan
- [x] All 190 specs pass (0 failures, 1 pre-existing pending)
- [x] ESLint passes
- [x] Local tests (36 specs)
- [x] Cluster tests (11 specs)
- [x] JSON tests (12 specs)
- [x] Expiry tests (8 specs)
- [x] SSL tests (11 specs)
- [x] Cross-site tests (2 specs)
- [x] Failover tests (1 spec)
- [x] Failover listener tests (1 spec)