### PR TITLE
Skip redundant AUTH when SASL authentication is already complete

### DIFF
--- a/lib/io.js
+++ b/lib/io.js
@@ -1116,6 +1116,9 @@
       f.actions(p.stepsHeaderBody(ctx, 0x23, p.sasl(transport.authOpts(), holder), undefined), codec.bytesEncoded)(ctx);
       var result = transport.writeCommandPinned(ctx, p.decodeSasl, conn);
       return result.then(function (r) {
+        if (r.complete) {
+          return r;
+        }
         ctx = u.context(16);
         ctx.topologyId = topologyId;
         holder.challenge = r.response;
@@ -1123,7 +1126,6 @@
         return transport.writeCommandPinned(ctx, p.decodeSasl, conn).then(function (r) {
           return r;
         });
-        return r;
       });
     }
 

--- a/lib/protocols.js
+++ b/lib/protocols.js
@@ -1105,9 +1105,9 @@
         var authDone = DECODE_UBYTE(bytebuf);
         if(authDone == 1) {
           logger.tracef('SASL authentication complete');
-          return {result:  {response: DECODE_UBYTE(bytebuf)}, continue: true};
+          return {result:  {response: DECODE_UBYTE(bytebuf), complete: true}, continue: true};
         } else {
-          return {result:  {response: DECODE_STRING(bytebuf)}, continue: true};
+          return {result:  {response: DECODE_STRING(bytebuf), complete: false}, continue: true};
         }
       }
     };


### PR DESCRIPTION
## Summary
- The `auth()` function unconditionally sent two AUTH messages during SASL authentication
- For single-step mechanisms like PLAIN, the server completes auth on the first message, making the second redundant
- The redundant AUTH can race with the server's SaslServer cleanup, causing intermittent `ELY05001: Authentication mechanism exchange received a message after authentication was already complete`
- Expose the server's `authDone` flag as a `complete` field in the `decodeSasl` result and skip the second round-trip when auth is already done
- Multi-step mechanisms like SCRAM-SHA continue to use both rounds as before

Fixes #155

Created with the assistance of an AI tool